### PR TITLE
fix sampler reading for mono samples, and tweak planetary orbit example

### DIFF
--- a/examples/PlanetaryOrbits.ipynb
+++ b/examples/PlanetaryOrbits.ipynb
@@ -247,8 +247,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "soni.save_combined(\"../../FILENAME.wav\", True, master_volume=1.0)"
+    "soni.save(\"../../FILENAME.wav\", master_volume=1.0)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "310cbcfa-ce02-4bec-bed7-da798ffebec7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -267,7 +275,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/src/strauss/generator.py
+++ b/src/strauss/generator.py
@@ -578,8 +578,11 @@ class Sampler(Generator):
             # If it doesn't match the required rate, resample and re-write
             if rate_in != self.samprate:
                 wavobj = utils.resample(rate_in, self.samprate, wavobj)
-            # force to mono
-            wavdat = np.mean(wavobj.data, axis=1)
+            # force to mono array, else convert values to float
+            if wavobj.ndim > 1:
+                wavdat = np.mean(wavobj.data, axis=1)
+            else:
+                wavdat = np.array(wavobj.data, dtype='float64')
             # remove DC term 
             dc = wavdat.mean()
             wavdat -= dc


### PR DESCRIPTION
some tweaks to sample reading so that the `PlanetaryOrbits.ipynb` example works as expected, following Issue https://github.com/james-trayford/strauss/issues/15

- only force samples to mono if they're not mono already! otherwise convert array to expected format
- use updated save routine in `PlanetaryOrbits.ipynb`