### PR TITLE
PortAudio patch

### DIFF
--- a/src/strauss/sonification.py
+++ b/src/strauss/sonification.py
@@ -370,7 +370,7 @@ class Sonification:
             sd.play(outfmt,self.out_channels['0'].samprate,blocking=1)
         except OSError as error: 
             print(error) 
-            print("The Sonification.hear() function requires the PortAudio C-library. This may be missing from your system or "
-                  "unsupported in this context. This should be installed by pip on Windows and OSx automatically with the "
+            print("The Sonification.hear() function requires the PortAudio C-library. This may be missing from your system or \n"
+                  "unsupported in this context. This should be installed by pip on Windows and OSx automatically with the \n "
                   "sounddevice library, but on Linux you may need to install manually using e.g.:\n"
                   "\t 'sudo apt-get install libportaudio2.'\n")

--- a/src/strauss/sonification.py
+++ b/src/strauss/sonification.py
@@ -15,7 +15,7 @@ Todo:
 
 from .stream import Stream
 from .channels import audio_channels
-from .utilities import const_or_evo, nested_dict_idx_reassign
+from .utilities import const_or_evo, nested_dict_idx_reassign, NoSoundDevice
 import numpy as np
 import matplotlib.pyplot as plt
 from tqdm import tqdm
@@ -27,7 +27,10 @@ import IPython.display as ipd
 from IPython.core.display import display
 from scipy.io import wavfile
 import warnings
-import sounddevice as sd
+try:
+    import sounddevice as sd
+except OSError as sderr:
+    sd = NoSoundDevice(sderr)
 
 class Sonification:
     """Representing the overall sonification

--- a/src/strauss/utilities.py
+++ b/src/strauss/utilities.py
@@ -3,6 +3,17 @@ import operator
 import numpy as np
 from scipy.interpolate import interp1d
 
+
+class NoSoundDevice:
+    """
+    drop-in replacement for sounddevice module if not working,
+    so can still use other functionality.
+    """
+    def __init__(self, err):
+        self.err = err
+    def play(self, audio, rate, blocking=1):
+        raise self.err
+        
 # a load of utility functions used by STRAUSS
 
 def nested_dict_reassign(fromdict, todict):


### PR DESCRIPTION
Patch to avoid errors in the `Sonification` module triggered by `sounddevice` if `PortAudio` is missing. Now we catch the import error and only throw it if trying to run the `Sonification.hear()` function where it's used, otherwise strauss functionality can be used as normal.