### PR TITLE
Some minor fixes

### DIFF
--- a/src/strauss/sonification.py
+++ b/src/strauss/sonification.py
@@ -29,7 +29,7 @@ from scipy.io import wavfile
 import warnings
 try:
     import sounddevice as sd
-except OSError as sderr:
+except (OSError, ModuleNotFoundError) as sderr:
     sd = NoSoundDevice(sderr)
 
 class Sonification:

--- a/src/strauss/sources.py
+++ b/src/strauss/sources.py
@@ -200,10 +200,13 @@ class Source:
                     # string values notate percentile limits
                     pc = float(l)
                     buff = 1
+                    sub = 0
                     if pc > 100:
+                        # if percentile over 100 we add 
                         buff = pc/100.
                         pc = 100
-                    lim = np.percentile(np.hstack([mapvals]), pc)*buff
+                        sub = lims[0]
+                    lim = sub + (np.percentile(np.hstack([mapvals]), pc) - sub)*buff
                     lims.append(lim)
                 else:
                     # numerical values notate absolute limits


### PR DESCRIPTION
- Modify behaviour for > 100 percentile limits - extend by a fraction of the **_min-max range_** rather than a fraction of the absolute **_max_** value. This will prevent large extensions for ranges that are far from zero (e.g. recent stellar lightcurves in MJD). See Issue: https://github.com/james-trayford/strauss/issues/20
- Also catch `ModuleNotFoundError` that can get thrown when `PortAudio` isn't found by the `sounddevice` library.
