### PR TITLE
Supporting Soundfonts & text-to-speech

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,5 +82,9 @@ docs/_build/
 !data/samples/mallets/*.wav
 !data/samples/solar_system/*.wav
 
+# ignore sf2 files as these can be big...
+*.sf2
+*.sfz
+
 # Also don't want ipynb checkpoints commited to the repo
 */.ipynb_checkpoints/

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
     - pyyaml
     - scipy
     - setuptools >= 4.2
+    - sf2utils
     - sphinx
     - tqdm
     - wavio

--- a/examples/LightCurveSoundfonts.ipynb
+++ b/examples/LightCurveSoundfonts.ipynb
@@ -1,0 +1,308 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "50574812-08d1-4065-b13c-1c6e2be01168",
+   "metadata": {},
+   "source": [
+    "### <u> Using Soundfont (`sf2`) files in `strauss` </u>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5b00d4a-4666-47aa-926b-f1beabe126b1",
+   "metadata": {},
+   "source": [
+    "Soundfont files conveniently package recorded samples of musical instruments together, to build realistic sounding virtual instruments. \n",
+    "\n",
+    "We can read such files into `strauss` when sonifying data!\n",
+    "\n",
+    "First we import some modules:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59e18a31-63e2-469c-8929-ee754d38c979",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "%reload_ext autoreload \n",
+    "%autoreload 2\n",
+    "import matplotlib.pyplot as plt\n",
+    "from strauss.sonification import Sonification\n",
+    "from strauss.sources import Objects, Events\n",
+    "from strauss import channels\n",
+    "from strauss.score import Score\n",
+    "import numpy as np\n",
+    "from strauss.generator import Sampler\n",
+    "import IPython.display as ipd\n",
+    "import glob\n",
+    "import os\n",
+    "import copy\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6d15169-dc7a-4e13-9aef-35fc2e8c73f9",
+   "metadata": {},
+   "source": [
+    "...and then download some soundfont (`sf2`) files. These are widely available online, and in particular we download some collected on the [_Soundfonts 4 U_](https://sites.google.com/site/soundfonts4u/) website (and hsted on _Google Drive_). Why not experiment with some of the other files hosted here? We select a flute and a collection of guitar sounds as these are small enough to automatically download.\n",
+    "\n",
+    "Don't worry too much about this code, you can equally download these files through your browser if you find this more convenient"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcd4634f-7f34-459e-a90e-7b2f933633b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outdir = \"../data/samples/soundfonts/\"\n",
+    "\n",
+    "if glob.glob(f\"{outdir}/*.sf2\"):\n",
+    "    print(f\"Directory {outdir} with sf2 files already exists.\")\n",
+    "else:\n",
+    "    print(\"Downloading files...\")\n",
+    "    import urllib.request\n",
+    "    import os\n",
+    "\n",
+    "    path = Path(outdir)\n",
+    "    path.mkdir(parents=True, exist_ok=True)\n",
+    "    path = str(path)\n",
+    "    # path = os.path.realpath(outdir)\n",
+    "    \n",
+    "    files = (\"guitars.sf2\", \"flute.sf2\")\n",
+    "    urls = (\"https://drive.google.com/uc?export=download&id=18CCYj8AFy7wpDdGg0ADx8GfTTHEFilrs\",\n",
+    "           \"https://drive.google.com/uc?export=download&id=1DAbIitPRUUGidrhVt4wiwwXrSxOD7RDY\")\n",
+    "    for f, u in zip(files, urls):\n",
+    "        with urllib.request.urlopen(u) as response, open(f\"{path}/{f}\", 'wb') as out_file:\n",
+    "            print(f\"\\t getting {f}\")\n",
+    "            data = response.read() # a `bytes` object\n",
+    "            out_file.write(data)\n",
+    "    print(\"Done.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d62e1757-c45a-4d65-bc7c-55dfbc84782f",
+   "metadata": {},
+   "source": [
+    "Now we have these files, lets try loading them into the sampler.\n",
+    "\n",
+    "First the ***flute*** soundfont. Generally soundfonts can store multiple different instruments or sets of sounds as `\"presets\"`. The flute file has just a single flute instruments, so if we load this file it should pick this preset automatically with no complaints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e258787-28bf-4e7c-8666-af11359ff404",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flute_sampler = Sampler(outdir+\"flute.sf2\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93064d16-b499-4d35-ac92-22ca2ee33c13",
+   "metadata": {},
+   "source": [
+    "On the other hand, the ***guitar*** file has multiple presets. If we try loading this in in the same way, the `_strauss_` sampler will make you pick the preset to use, via its preset number. Enter a number from the list, and press _Enter_ to to select it. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41d1180e-d9c5-470f-9634-afb67e75f663",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "guitar_sampler = Sampler(outdir+\"guitars.sf2\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff94447a-3b0f-48fc-8fd3-70be45bd22d4",
+   "metadata": {},
+   "source": [
+    "This interface can be useful to inspect whats inside the soundfont file, but to avoid this, we can pick the preset ahead of time, using the `sf_preset` keyword argument:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a064a24e-82ea-4204-997b-a819604a5e4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sf_preset = 19\n",
+    "guitar_sampler= Sampler(outdir+\"guitars.sf2\", sf_preset=sf_preset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98526536-0a54-4efa-b103-0b133ce3de5c",
+   "metadata": {},
+   "source": [
+    "So, lets try using these files to sonify data series. We use light-curve data packaged for the star `55 Cancri`. This provides a noisy data set with interesting long and short term variations, as well as a gap in the data.\n",
+    "\n",
+    "First, we can articulate each data-point using individual musical notes, chosen from a musical scale (`C Major Pentatonic`). We visualise this using a scztter plot, where each data point is repreesented individually.\n",
+    "\n",
+    "When listening to many data points in quick succession, the _\"note_length\"_ and _\"volume_envelope_\" can be important, i.e. how the loudness of the sound changes over time. If each note plays for a long time, we could lose track of the individual notes. We want each note to be a short burst of sound - _\"staccato\"_ in musical terms. Here we set parameters to achieve this manually, but you can also just use the _`\"staccato\"`_ preset for the `Sampler` (commented out).\n",
+    "\n",
+    "Here, we use 0.03 second (30 ms) as the note duration, but what if we changed this to 1 second?\n",
+    "\n",
+    "You should find it harder to the clear articulation of individual data points, for example the regular dips in the light curve are harder to hear - this can sound good, but is less informative. Note also how we hear the large gap in data points where the sound stops for some time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "270fa0e5-5cc3-4712-a4a6-b9d5718d7624",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pick a soundfont to use\n",
+    "\n",
+    "#generator = guitar_sampler\n",
+    "generator = copy.copy(flute_sampler)\n",
+    "\n",
+    "lightcurve = np.genfromtxt('../data/datasets/55Cancri_lc.dat')\n",
+    "x = lightcurve[:,0][:]\n",
+    "y = lightcurve[:,1][:]\n",
+    "\n",
+    "score =  Score(notes, 15)\n",
+    "\n",
+    "notes = [[\"C3\",\"D3\",\"E3\",\"G3\",\"B3\",\"C4\",\"D4\",\"E4\",\"G4\",\"B4\",\"C5\",\"D5\",\"E5\",\"G5\",\"B5\"]]\n",
+    "        \n",
+    "maps = {'pitch':y,\n",
+    "        'time': x}\n",
+    "\n",
+    "system = \"mono\"\n",
+    "\n",
+    "# manually set note properties to get a suitable sound\n",
+    "generator.modify_preset({'note_length':0.03, # hold each note for 0.03 seconds or 30 ms - what if this was 1s?\n",
+    "                         'volume_envelope': {'use':'on',\n",
+    "                                            # A,D,R values in seconds, S sustain fraction from 0-1 that note\n",
+    "                                            # will 'decay' to (after time A+D)\n",
+    "                                            'A':0.01,    # ✏️ Time to fade in note to maximum volume, using 10 ms\n",
+    "                                            'D':0.0,    # ✏️ Time to fall from maximum volume to sustained level (s), irrelevant while S is 1 \n",
+    "                                            'S':1.,      # ✏️ fraction of maximum volume to sustain note at while held, 1 implies 100% \n",
+    "                                            'R':0.07}}) # ✏️ Time to fade out once note is released, using 100 ms\n",
+    "\n",
+    "# alternatively can avoid setting manually above anf just load the 'staccato' preset\n",
+    "# generator.load_preset('staccato')\n",
+    "\n",
+    "# set 0 to 100 percentile limits so the full pitch range is used...\n",
+    "# setting 0 to 101 for pitch means the sonification is 1% longer than\n",
+    "# the time needed to trigger each note - by making this more than 100%\n",
+    "# we give all the notes time to ring out (setting this at 100% means\n",
+    "# the final note is triggered at the momement the sonification ends)\n",
+    "lims = {'time': ('0','101'),\n",
+    "        'pitch': ('0','100')}\n",
+    "\n",
+    "# set up source\n",
+    "sources = Events(maps.keys())\n",
+    "sources.fromdict(maps)\n",
+    "sources.apply_mapping_functions(map_lims=lims)\n",
+    "\n",
+    "soni = Sonification(score, sources, generator, system)\n",
+    "soni.render()\n",
+    "dobj = soni.notebook_display(show_waveform=0)\n",
+    "\n",
+    "plt.scatter(x,y, marker='.')\n",
+    "plt.ylabel('Magnitude')\n",
+    "plt.xlabel('Time (Julian Days)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc16db9a-61ba-4665-b8a8-f097db5d19ea",
+   "metadata": {},
+   "source": [
+    "For a different approach, we can use an `Object` source type, where we evolve a sound over time to represent the data. Here we represent the same data using a held chord, and change the _`\"cutoff\"`_ frequency of the low-pass filter to create a 'brighter' timbre when the star is brighter and a 'darker' sound when the star is darker.\n",
+    "\n",
+    "When using samples in this way, we want to achieve certain properties:\n",
+    "\n",
+    "- A sound that will last the length of the sonification: To achieve this we can use _\"looping\"_, where part of the sample is repeated indefinitely, choosing the looping style and start and end points.\n",
+    "- A sound that has little intrinsic variation: for a example a short, percussive sound like a plucked string will lead to large volume variations when looping, that can be distractibg from the variation due to the data we're interested in. An instrument like a violin or organ can loop more smoothly.\n",
+    "- A \"harmonically rich\" sound: By choosing an instrument with a more trebly or 'bright' timbre, the filter variations will be easier to hear\n",
+    "\n",
+    "For example we use an overdriven guitar sound by default. This sound loops well as it fades away slowly, and the distorition makes int harmonically rich. How about trying some other presets for the `guitar_sampler` above by choosing a different `sf_preset` value?\n",
+    "\n",
+    "To visualise this we use a line graph - this uses a continuous, varying line to represent the data series, analogous to the evolving sound. In the line graph we see that the data gap is interpolated over, connecting the data points either side of the gap. In the `Object` representation the same effect is heard in the sound - the sound varies smoothly over the gap."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcda9bd1-c838-45db-a316-eeee2b0ef21f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pick a soundfont to use\n",
+    "\n",
+    "generator = copy.copy(guitar_sampler)\n",
+    "#generator = flute_sampler\n",
+    "\n",
+    "generator.modify_preset({'filter':'on'})\n",
+    "\n",
+    "# manually set looping parameters \n",
+    "generator.modify_preset({'looping':'forwardback',\n",
+    "                         'loop_start': 0.2, 'loop_end': 0.5}) # ✏️ for such a fast sequence, using ~10 ms values\n",
+    "\n",
+    "# or, just load the 'sustain' preset\n",
+    "# generator.load_preset('sustain')\n",
+    "\n",
+    "# we use a 'chord' here to create more harmonic richness (stacking fifths)...\n",
+    "notes = [[\"E2\", \"B2\"]]\n",
+    "score =  Score(notes, 15)\n",
+    "\n",
+    "data = {'pitch':[0,1,2,3],\n",
+    "        'time_evo':[x]*4,\n",
+    "        'cutoff':[y]*4}\n",
+    "\n",
+    "lims = {'time_evo': ('0','100'),\n",
+    "        'cutoff': ('0','100')}\n",
+    "\n",
+    "# set up source\n",
+    "sources = Objects(data.keys())\n",
+    "sources.fromdict(data)\n",
+    "plims = {'cutoff': (0.25,0.95)}\n",
+    "sources.apply_mapping_functions(map_lims=lims, param_lims=plims)\n",
+    "\n",
+    "soni = Sonification(score, sources, generator, system)\n",
+    "soni.render()\n",
+    "dobj = soni.notebook_display(show_waveform=0);\n",
+    "plt.plot(x,y)\n",
+    "plt.ylabel('Magnitude')\n",
+    "plt.xlabel('Time (Julian Days)')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/colab/LightCurveSoundfonts.ipynb
+++ b/examples/colab/LightCurveSoundfonts.ipynb
@@ -1,0 +1,370 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "af1380f6-87a4-4a71-9371-f34f09e327dd",
+   "metadata": {},
+   "source": [
+    "#### Preamble for `CoLab` "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3371a13-4791-4060-93a9-f8584d92f766",
+   "metadata": {},
+   "source": [
+    "To use this notebook (if you haven't already) you can first save a copy to your local drive by clicking `File > Save a Copy in Drive` and run on that copy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b68cb439-44e5-45d7-bc7f-99327d98aa07",
+   "metadata": {},
+   "source": [
+    "_Note_: `Colab` is a really handy way to test and try `strauss`, though it will generally run and display audio more slowly than running on your local machine. For a more responsive experience, why not install `strauss` locally, following the instructions [on the Github](https://github.com/james-trayford/strauss)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d961ed9a-135e-4d00-8561-316122d73b52",
+   "metadata": {},
+   "source": [
+    "Run these cells, so that the notebook functions on the _Google_ `Colab` platform:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9d3764f-286b-440c-a52a-3aaee05aae43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip --quiet install strauss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e93f842-fed6-480c-9910-22f9e85a948b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!git clone https://github.com/james-trayford/strauss.git"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9f03648-820a-4c3e-b182-f4bbb42b4343",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%cd strauss/examples/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50574812-08d1-4065-b13c-1c6e2be01168",
+   "metadata": {},
+   "source": [
+    "### <u> Using Soundfont (`sf2`) files in `strauss` </u>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5b00d4a-4666-47aa-926b-f1beabe126b1",
+   "metadata": {},
+   "source": [
+    "Soundfont files conveniently package recorded samples of musical instruments together, to build realistic sounding virtual instruments. \n",
+    "\n",
+    "We can read such files into `strauss` when sonifying data!\n",
+    "\n",
+    "First we import some modules:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59e18a31-63e2-469c-8929-ee754d38c979",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "%reload_ext autoreload \n",
+    "%autoreload 2\n",
+    "import matplotlib.pyplot as plt\n",
+    "from strauss.sonification import Sonification\n",
+    "from strauss.sources import Objects, Events\n",
+    "from strauss import channels\n",
+    "from strauss.score import Score\n",
+    "import numpy as np\n",
+    "from strauss.generator import Sampler\n",
+    "import IPython.display as ipd\n",
+    "import glob\n",
+    "import os\n",
+    "import copy\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6d15169-dc7a-4e13-9aef-35fc2e8c73f9",
+   "metadata": {},
+   "source": [
+    "...and then download some soundfont (`sf2`) files. These are widely available online, and in particular we download some collected on the [_Soundfonts 4 U_](https://sites.google.com/site/soundfonts4u/) website (and hsted on _Google Drive_). Why not experiment with some of the other files hosted here? We select a flute and a collection of guitar sounds as these are small enough to automatically download.\n",
+    "\n",
+    "Don't worry too much about this code, you can equally download these files through your browser if you find this more convenient"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcd4634f-7f34-459e-a90e-7b2f933633b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outdir = \"../data/samples/soundfonts/\"\n",
+    "\n",
+    "if glob.glob(f\"{outdir}/*.sf2\"):\n",
+    "    print(f\"Directory {outdir} with sf2 files already exists.\")\n",
+    "else:\n",
+    "    print(\"Downloading files...\")\n",
+    "    import urllib.request\n",
+    "    import os\n",
+    "\n",
+    "    path = Path(outdir)\n",
+    "    path.mkdir(parents=True, exist_ok=True)\n",
+    "    path = str(path)\n",
+    "    # path = os.path.realpath(outdir)\n",
+    "    \n",
+    "    files = (\"guitars.sf2\", \"flute.sf2\")\n",
+    "    urls = (\"https://drive.google.com/uc?export=download&id=18CCYj8AFy7wpDdGg0ADx8GfTTHEFilrs\",\n",
+    "           \"https://drive.google.com/uc?export=download&id=1DAbIitPRUUGidrhVt4wiwwXrSxOD7RDY\")\n",
+    "    for f, u in zip(files, urls):\n",
+    "        with urllib.request.urlopen(u) as response, open(f\"{path}/{f}\", 'wb') as out_file:\n",
+    "            print(f\"\\t getting {f}\")\n",
+    "            data = response.read() # a `bytes` object\n",
+    "            out_file.write(data)\n",
+    "    print(\"Done.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d62e1757-c45a-4d65-bc7c-55dfbc84782f",
+   "metadata": {},
+   "source": [
+    "Now we have these files, lets try loading them into the sampler.\n",
+    "\n",
+    "First the ***flute*** soundfont. Generally soundfonts can store multiple different instruments or sets of sounds as `\"presets\"`. The flute file has just a single flute instruments, so if we load this file it should pick this preset automatically with no complaints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e258787-28bf-4e7c-8666-af11359ff404",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flute_sampler = Sampler(outdir+\"flute.sf2\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93064d16-b499-4d35-ac92-22ca2ee33c13",
+   "metadata": {},
+   "source": [
+    "On the other hand, the ***guitar*** file has multiple presets. If we try loading this in in the same way, the `_strauss_` sampler will make you pick the preset to use, via its preset number. Enter a number from the list, and press _Enter_ to to select it. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41d1180e-d9c5-470f-9634-afb67e75f663",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "guitar_sampler = Sampler(outdir+\"guitars.sf2\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff94447a-3b0f-48fc-8fd3-70be45bd22d4",
+   "metadata": {},
+   "source": [
+    "This interface can be useful to inspect whats inside the soundfont file, but to avoid this, we can pick the preset ahead of time, using the `sf_preset` keyword argument:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a064a24e-82ea-4204-997b-a819604a5e4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sf_preset = 19\n",
+    "guitar_sampler= Sampler(outdir+\"guitars.sf2\", sf_preset=sf_preset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98526536-0a54-4efa-b103-0b133ce3de5c",
+   "metadata": {},
+   "source": [
+    "So, lets try using these files to sonify data series. We use light-curve data packaged for the star `55 Cancri`. This provides a noisy data set with interesting long and short term variations, as well as a gap in the data.\n",
+    "\n",
+    "First, we can articulate each data-point using individual musical notes, chosen from a musical scale (`C Major Pentatonic`). We visualise this using a scztter plot, where each data point is repreesented individually.\n",
+    "\n",
+    "When listening to many data points in quick succession, the _\"note_length\"_ and _\"volume_envelope_\" can be important, i.e. how the loudness of the sound changes over time. If each note plays for a long time, we could lose track of the individual notes. We want each note to be a short burst of sound - _\"staccato\"_ in musical terms. Here we set parameters to achieve this manually, but you can also just use the _`\"staccato\"`_ preset for the `Sampler` (commented out).\n",
+    "\n",
+    "Here, we use 0.03 second (30 ms) as the note duration, but what if we changed this to 1 second?\n",
+    "\n",
+    "You should find it harder to the clear articulation of individual data points, for example the regular dips in the light curve are harder to hear - this can sound good, but is less informative. Note also how we hear the large gap in data points where the sound stops for some time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "270fa0e5-5cc3-4712-a4a6-b9d5718d7624",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pick a soundfont to use\n",
+    "\n",
+    "#generator = guitar_sampler\n",
+    "generator = copy.copy(flute_sampler)\n",
+    "\n",
+    "lightcurve = np.genfromtxt('../data/datasets/55Cancri_lc.dat')\n",
+    "x = lightcurve[:,0][:]\n",
+    "y = lightcurve[:,1][:]\n",
+    "\n",
+    "score =  Score(notes, 15)\n",
+    "\n",
+    "notes = [[\"C3\",\"D3\",\"E3\",\"G3\",\"B3\",\"C4\",\"D4\",\"E4\",\"G4\",\"B4\",\"C5\",\"D5\",\"E5\",\"G5\",\"B5\"]]\n",
+    "        \n",
+    "maps = {'pitch':y,\n",
+    "        'time': x}\n",
+    "\n",
+    "system = \"mono\"\n",
+    "\n",
+    "# manually set note properties to get a suitable sound\n",
+    "generator.modify_preset({'note_length':0.03, # hold each note for 0.03 seconds or 30 ms - what if this was 1s?\n",
+    "                         'volume_envelope': {'use':'on',\n",
+    "                                            # A,D,R values in seconds, S sustain fraction from 0-1 that note\n",
+    "                                            # will 'decay' to (after time A+D)\n",
+    "                                            'A':0.01,    # ✏️ Time to fade in note to maximum volume, using 10 ms\n",
+    "                                            'D':0.0,    # ✏️ Time to fall from maximum volume to sustained level (s), irrelevant while S is 1 \n",
+    "                                            'S':1.,      # ✏️ fraction of maximum volume to sustain note at while held, 1 implies 100% \n",
+    "                                            'R':0.07}}) # ✏️ Time to fade out once note is released, using 100 ms\n",
+    "\n",
+    "# alternatively can avoid setting manually above anf just load the 'staccato' preset\n",
+    "# generator.load_preset('staccato')\n",
+    "\n",
+    "# set 0 to 100 percentile limits so the full pitch range is used...\n",
+    "# setting 0 to 101 for pitch means the sonification is 1% longer than\n",
+    "# the time needed to trigger each note - by making this more than 100%\n",
+    "# we give all the notes time to ring out (setting this at 100% means\n",
+    "# the final note is triggered at the momement the sonification ends)\n",
+    "lims = {'time': ('0','101'),\n",
+    "        'pitch': ('0','100')}\n",
+    "\n",
+    "# set up source\n",
+    "sources = Events(maps.keys())\n",
+    "sources.fromdict(maps)\n",
+    "sources.apply_mapping_functions(map_lims=lims)\n",
+    "\n",
+    "soni = Sonification(score, sources, generator, system)\n",
+    "soni.render()\n",
+    "dobj = soni.notebook_display(show_waveform=0)\n",
+    "\n",
+    "plt.scatter(x,y, marker='.')\n",
+    "plt.ylabel('Magnitude')\n",
+    "plt.xlabel('Time (Julian Days)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc16db9a-61ba-4665-b8a8-f097db5d19ea",
+   "metadata": {},
+   "source": [
+    "For a different approach, we can use an `Object` source type, where we evolve a sound over time to represent the data. Here we represent the same data using a held chord, and change the _`\"cutoff\"`_ frequency of the low-pass filter to create a 'brighter' timbre when the star is brighter and a 'darker' sound when the star is darker.\n",
+    "\n",
+    "When using samples in this way, we want to achieve certain properties:\n",
+    "\n",
+    "- A sound that will last the length of the sonification: To achieve this we can use _\"looping\"_, where part of the sample is repeated indefinitely, choosing the looping style and start and end points.\n",
+    "- A sound that has little intrinsic variation: for a example a short, percussive sound like a plucked string will lead to large volume variations when looping, that can be distractibg from the variation due to the data we're interested in. An instrument like a violin or organ can loop more smoothly.\n",
+    "- A \"harmonically rich\" sound: By choosing an instrument with a more trebly or 'bright' timbre, the filter variations will be easier to hear\n",
+    "\n",
+    "For example we use an overdriven guitar sound by default. This sound loops well as it fades away slowly, and the distorition makes int harmonically rich. How about trying some other presets for the `guitar_sampler` above by choosing a different `sf_preset` value?\n",
+    "\n",
+    "To visualise this we use a line graph - this uses a continuous, varying line to represent the data series, analogous to the evolving sound. In the line graph we see that the data gap is interpolated over, connecting the data points either side of the gap. In the `Object` representation the same effect is heard in the sound - the sound varies smoothly over the gap."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcda9bd1-c838-45db-a316-eeee2b0ef21f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pick a soundfont to use\n",
+    "\n",
+    "generator = copy.copy(guitar_sampler)\n",
+    "#generator = flute_sampler\n",
+    "\n",
+    "generator.modify_preset({'filter':'on'})\n",
+    "\n",
+    "# manually set looping parameters \n",
+    "generator.modify_preset({'looping':'forwardback',\n",
+    "                         'loop_start': 0.2, 'loop_end': 0.5}) # ✏️ for such a fast sequence, using ~10 ms values\n",
+    "\n",
+    "# or, just load the 'sustain' preset\n",
+    "# generator.load_preset('sustain')\n",
+    "\n",
+    "# we use a 'chord' here to create more harmonic richness (stacking fifths)...\n",
+    "notes = [[\"E2\", \"B2\"]]\n",
+    "score =  Score(notes, 15)\n",
+    "\n",
+    "data = {'pitch':[0,1,2,3],\n",
+    "        'time_evo':[x]*4,\n",
+    "        'cutoff':[y]*4}\n",
+    "\n",
+    "lims = {'time_evo': ('0','100'),\n",
+    "        'cutoff': ('0','100')}\n",
+    "\n",
+    "# set up source\n",
+    "sources = Objects(data.keys())\n",
+    "sources.fromdict(data)\n",
+    "plims = {'cutoff': (0.25,0.95)}\n",
+    "sources.apply_mapping_functions(map_lims=lims, param_lims=plims)\n",
+    "\n",
+    "soni = Sonification(score, sources, generator, system)\n",
+    "soni.render()\n",
+    "dobj = soni.notebook_display(show_waveform=0);\n",
+    "plt.plot(x,y)\n",
+    "plt.ylabel('Magnitude')\n",
+    "plt.xlabel('Time (Julian Days)')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires = [
     "pychord",	
     "scipy",
     "setuptools>=42",
+    "sf2utils",
     "tqdm",
     "wavio",
     "wheel"

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
  wavio
  wheel
  sounddevice
+ sf2utils
 [options.packages.find]
 where = src
 

--- a/src/strauss/generator.py
+++ b/src/strauss/generator.py
@@ -400,20 +400,21 @@ class Synthesizer(Generator):
         :obj:`self.generate` method, using the
         :obj:`self.combine_oscs`.
         """
-        oscdict = self.preset['oscillators']
-        self.osclist = []
-        for osc in oscdict.keys():
-            lvl = oscdict[osc]['level']
-            det = oscdict[osc]['detune']
-            phase = oscdict[osc]['phase']
-            form = oscdict[osc]['form']
-            snorm = self.samprate
-            fnorm = (1 + det/100.)
-            if phase == 'random':
-                oscf = lambda samp, f: lvl * getattr(self,form)(samp/snorm, f*fnorm, np.random.random())
-            else:
-                oscf = lambda samp, f: lvl * getattr(self,form)(samp/snorm, f*fnorm, phase)
-            self.osclist.append(oscf)
+        # oscdict = self.preset['oscillators']
+        # self.osclist = []
+        # for osc in oscdict.keys():
+        #     lvl = oscdict[osc]['level']
+        #     det = oscdict[osc]['detune']
+        #     phase = oscdict[osc]['phase']
+        #     form = oscdict[osc]['form']
+        #     snorm = self.samprate
+        #     fnorm = (1 + det/100.)
+        #     if phase == 'random':
+        #         oscf = lambda samp, f: lvl * getattr(self,form)(samp/snorm, f*fnorm, np.random.random())
+        #     else:
+        #         oscf = lambda samp, f: lvl * getattr(self,form)(samp/snorm, f*fnorm, phase)
+        #     self.osclist.append(oscf)
+        #     flg += 1
         self.generate = self.combine_oscs
 
     def modify_preset(self, parameters, clear_oscs=True):
@@ -446,11 +447,23 @@ class Synthesizer(Generator):
           tot (:obj:`array`-like): values for each sample
         """
         tot = 0.
+        oscdict = self.preset['oscillators']
         if isinstance(f, str):
             # we want a numerical frequency to generate tone
             f = notes.parse_note(f)
-        for osc in self.osclist:
-            tot += osc(s,f)
+        for osc in oscdict:
+            lvl = oscdict[osc]['level']
+            det = oscdict[osc]['detune']
+            phase = oscdict[osc]['phase']
+            form = oscdict[osc]['form']
+            snorm = self.samprate
+            fnorm = (1 + det/100.)
+            if phase == 'random':
+                tot += lvl * getattr(self,form)(s/snorm, f*fnorm, np.random.random())
+            else:
+                tot += lvl * getattr(self,form)(s/snorm, f*fnorm, phase)
+            # self.osclist.append(oscf)
+            # flg += 1
         return tot
 
     def play(self, mapping):

--- a/src/strauss/generator.py
+++ b/src/strauss/generator.py
@@ -587,8 +587,8 @@ class Sampler(Generator):
                     npres = len(self.sf2.raw.pdta['Phdr'][:-1])
                     if npres == 1:
                         # if there's only one preset, choose it
-                        sf_preset = 0
-                    if not (isinstance(sf_preset, int) and (sf_preset >= 0) and (sf_preset < npres)):
+                        sf_preset = 1
+                    if not (isinstance(sf_preset, int) and (sf_preset >= 1) and (sf_preset <= npres)):
                         # if there's more than one, and no valid number specified, ask for one.
                         print("valid 'sf_preset' not provided for soundfont file, choose from:")
                         print('\n'+''.join(['-']*80))
@@ -597,12 +597,12 @@ class Sampler(Generator):
                             print(f"{i+1}. {hdr.name.decode('utf-8')}")
                         print(''.join(['-']*80)+'\n')
                         # TODO: zero index, but would 1 index be more user friendly?
-                        sf_preset = int(input(f"Choose Preset Number (0-{i}): \t"))
+                        sf_preset = int(input(f"Choose Preset Number (1-{i+1}): \t"))
                     # TODO: isolate the warning suppression better?
                     logger = logging.getLogger()
                     pres = self.sf2.build_presets()
                     logger.disabled = True
-                    sf_data = self.get_sfpreset_samples(pres[sf_preset])
+                    sf_data = self.get_sfpreset_samples(pres[sf_preset-1])
                     self.sampdict = self.reconstruct_samples(sf_data)
                     logger.disabled = False
                     

--- a/src/strauss/generator.py
+++ b/src/strauss/generator.py
@@ -28,6 +28,7 @@ from scipy.fft import fft, ifft, fftfreq
 import glob
 import copy
 import scipy
+import json
 from scipy.io import wavfile
 from scipy.interpolate import interp1d
 import matplotlib.pyplot as plt
@@ -594,7 +595,8 @@ class Sampler(Generator):
                         print('\n'+''.join(['-']*80))
                         for i in range(npres):
                             hdr = self.sf2.raw.pdta['Phdr'][i]
-                            print(f"{i+1}. {hdr.name.decode('utf-8')}")
+                            name = json.dumps(hdr.name.decode('utf-8')).replace(r'\u0000', '')
+                            print(f"{i+1}. {name}")
                         print(''.join(['-']*80)+'\n')
                         # TODO: zero index, but would 1 index be more user friendly?
                         sf_preset = int(input(f"Choose Preset Number (1-{i+1}): \t"))

--- a/src/strauss/generator.py
+++ b/src/strauss/generator.py
@@ -694,8 +694,10 @@ class Sampler(Generator):
             for wave in wave_stack:
                 compwave[:wave.size] += wave//nwave
             nte = notes.mkey_to_note(i)
-            sampdict[nte] = compwave
-        
+            sampdict[nte] = compwave # return notes using sharps
+            if nte[1] == '#':
+                # if a sharp, also assign flat...
+                sampdict[nte.replace('#','b')] = compwave
             # outname = f'../../example_wavs/out_{nte}.wav'
             # write(outname, samprate, compwave)
         return sampdict

--- a/src/strauss/notes.py
+++ b/src/strauss/notes.py
@@ -35,3 +35,9 @@ def chord_notes(chordname, rootoct=3):
     chord = chrd.Chord(chordname)
     notes = chord.components_with_pitch(int(rootoct))
     return notes
+
+def mkey_to_note(val):
+    from strauss.notes import notesharps
+    octv = val // 12 - 1
+    semi = val % 12
+    return f'{notesharps[semi]}{octv}'

--- a/src/strauss/presets/sampler/staccato.yml
+++ b/src/strauss/presets/sampler/staccato.yml
@@ -1,0 +1,19 @@
+# preset name
+name: "staccato"
+
+# full description
+description: >-
+  Forces a short volume envelope on each sample, such that a note is held for 30ms and fades out over 70ms, giving 100ms
+  duration for each note to sound - works well to represent rapidly varying data using an Events source type.
+
+# Numerical note length in s or "sample" for the sample length or "none"
+# to last to the end of the 
+note_length: 0.03
+
+# define the note volume envelope applied to the samples
+# A,D,S & R correspond to 'attack', 'decay', 'sustain' and 'release'
+volume_envelope:
+  A: 0.01
+  D: 0.
+  S: 1.
+  R: 0.07

--- a/src/strauss/presets/sampler/sustain.yml
+++ b/src/strauss/presets/sampler/sustain.yml
@@ -1,0 +1,16 @@
+# preset name
+name: "sustain"
+
+# full description
+description: >-
+  Sustain a sample indefinitely, achieved by holding the note on and using a loop between
+  0.2 and 0.5 seconds - works well to represent Object source types that vary over an extended
+  period. This works best with extended samples or instruments that don't vary much, such as
+  a violin or organ. Short samples (< 1s) or those that are quick or percussive (e.g. a piano)
+  can lead to a regular variation in the sound that distracts from the data sonification.
+  Tweaking loop_start and loop_end can help create a smoother sound for a given sample.
+
+# use the 'forwardback' looping mode by default, between 0.2 and 0.5 seconds for each sample
+looping: "forwardback"
+loop_start: 0.2
+loop_end: 0.5

--- a/src/strauss/presets/synth/default.yml
+++ b/src/strauss/presets/synth/default.yml
@@ -31,12 +31,12 @@ oscillators:
   osc2:
     form: 'saw'
     level: 0.5
-    detune: -2.
+    detune: 0.75
     phase: 0.3
   osc3:
     form: 'saw'
     level: 0.5
-    detune: 2.
+    detune: 0.75
     phase: 0.6
 
 # Numerical note length in s

--- a/src/strauss/utilities.py
+++ b/src/strauss/utilities.py
@@ -2,7 +2,8 @@ from functools import reduce
 import operator
 import numpy as np
 from scipy.interpolate import interp1d
-
+from contextlib import contextmanager,redirect_stderr,redirect_stdout
+from os import devnull
 
 class NoSoundDevice:
     """
@@ -95,3 +96,9 @@ def resample(rate_in, samprate, wavobj):
     new_wavobj = np.round(interpolator(time_new).T).astype(wavobj.dtype)
     return(new_wavobj)
 
+@contextmanager
+def suppress_stdout_stderr():
+    """A context manager that redirects stdout and stderr to devnull"""
+    with open(devnull, 'w') as fnull:
+        with redirect_stderr(fnull) as err, redirect_stdout(fnull) as out:
+            yield (err, out)


### PR DESCRIPTION
- Supporting _Soundfont_ files (`.sf2`) in the `Sampler`:
  - Read and select presets from soundfont files
  - Add an example with a stellar light curve (notebooks and scripts)
  - Add some sampler presets that help with using soundfonts
  - Make sure to ignore `sf2` files in git so we don't end up committing these big files...
- Integrating Text-to-speech (TTS)
  - Add 'caption' functionality to allow you to annotate sonifications in strauss
  - Add example notebooks for local and Colab examples and script
  - Add TTS requirements as an 'extra' to strauss. This is because of the very specific module requirements of the TTS modules. you can install this extra for captioning functionality. 

Note the `examples/colab` directory containing versions of the notebooks with preambles that allow them to run in _Google Colab_. This can be opened using the github URL to the file and changing `github.com` to `githibtocolab.com`. This provides a way to test the notebooks in a 'fresh' environment. In particular, the `examples/colab/AudioCaption.ipynb` example by default should install the TTS extras to strauss. Without these extras captioning still fail, but all other aspects of strauss should work. Some of the default Colab modules don't play well with these modules, but examples should still work (though may complain and ask to reset the runtime)

 
 