### PR TITLE
Auto-doc `yml`s

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../../src/strauss/presets'))
 
 
 # -- Project information -----------------------------------------------------
@@ -35,7 +36,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
               'sphinx.ext.ifconfig', 'sphinx.ext.viewcode',
               'sphinx.ext.inheritance_diagram',
               'sphinx.ext.autosummary','sphinx.ext.coverage',
-              'sphinx.ext.napoleon']
+              'sphinx.ext.napoleon', "myst_parser"]
 #'recommonmark',
 #              'sphinx_markdown_tables'
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ The code aims to make rich and evocative sonification straightforward, with a nu
    start
    elements
    detailed
+   presets
    examples
    todo
   

--- a/src/strauss/presets/sampler/default.yml
+++ b/src/strauss/presets/sampler/default.yml
@@ -86,6 +86,7 @@ pitch_lo: 0
 pitch_shift: 0.
 
 _meta:
+  _doc: A top-level documentation string for the generator's defaults
   name: preset name
   description: full description
   note_length: >-
@@ -97,9 +98,6 @@ _meta:
     If looping, start and end point of loop in seconds.
   loop_end: >-
     If loop_end is longer than the sample, clip to end of the sample.
-  volume_envelope: >-
-    define the note volume envelope applied to the samples
-    A,D,S & R correspond to 'attack', 'decay', 'sustain' and 'release'
   volume_envelope:
     A: Attack
     D: Decay
@@ -132,9 +130,8 @@ _meta:
     Dc: ""
     Rc: ""
     level: ""
-  volume_lfo: >-
-    or apply 'tremolo'?
   volume_lfo:
+    _doc: define the note volume envelope applied to the samples A,D,S & R correspond to 'attack', 'decay', 'sustain' and 'release'
     use: switch feature on or off
     wave: type of waveform
     amount: amount

--- a/src/strauss/presets/sampler/default.yml
+++ b/src/strauss/presets/sampler/default.yml
@@ -131,7 +131,9 @@ _meta:
     Rc: ""
     level: ""
   volume_lfo:
-    _doc: define the note volume envelope applied to the samples A,D,S & R correspond to 'attack', 'decay', 'sustain' and 'release'
+    _doc: >-
+      define the note volume envelope applied to the samples A,D,S & R
+      correspond to 'attack', 'decay', 'sustain' and 'release'
     use: switch feature on or off
     wave: type of waveform
     amount: amount

--- a/yamls_to_tables.py
+++ b/yamls_to_tables.py
@@ -1,0 +1,64 @@
+import yaml
+from glob import glob
+from pathlib import Path
+
+generators = {'spec' : "`Spectraliser` Generator",
+              'synth' : "`Synthesiser` Generator",
+              'sampler' : "`Sampler` Generator"}
+
+# p = Path(__file__)
+p = Path("src", "strauss", "presets", "*", "default.yml")
+
+def read_yaml(filename):
+    with filename.open(mode='r') as fdata:
+        # try:
+            yamldict = yaml.safe_load(fdata)
+        # except yaml.YAMLError as err:
+        #     print(err)
+    return yamldict
+
+def yaml_traverse(metadict, valdict, rdict, headlev=1):
+    if hasattr(metadict, 'keys'):
+        topstr = ''
+        tabstr = ''
+        secstr = ''
+        tabstr += "\n| Parameter | Description | Default Value | Default Range | Unit |\n"
+        tabstr += "| ----------- | ----------- | ----------- | ----------- | ----------- |\n"
+                
+        for k in metadict.keys():
+            # print (f">>>>>> {k}")
+            if hasattr(metadict[k], 'keys'):
+                secstr += '\n'+''.join(['#']*headlev) + f" `{k}` parameter group\n"
+                if not k in rdict:
+                    rdict[k] = {}
+                secstr += yaml_traverse(metadict[k], valdict[k], rdict[k], headlev+1)
+                continue
+            if k == '_doc':
+                topstr += f"\n{metadict[k]}\n"
+                # print('\n',metadict[k])
+                continue
+            if k not in rdict:
+                # unspecified => '-'
+                rdict[k] = '-'
+            else:
+                # lets avoid these line-breaking with special characters
+                rdict[k] = str(rdict[k]).replace(" ","").replace(",","\u2011").replace("-","\u2011")
+            if k+"_unit" not in rdict:
+                # unspecified => '-'
+                rdict[k+"_unit"] = '-'
+            # print(f"|`{k}` |  _{metadict[k]}_ | `{str(valdict[k]).strip()}` | `{rdict[k]}` | {rdict[k+'_unit']}")
+            tabstr += f"|`{k}` |  _{str(metadict[k]).strip()}_ | `valdict[k]` | `{rdict[k]}` | {rdict[k+'_unit']}\n"
+            if k not in rdict:
+                rdict[k] = {}
+        return f'{topstr}{tabstr}{secstr}'
+
+    else:
+        return
+
+for f in glob(str(p)):
+    p = Path(f)
+    ydat = read_yaml(p)
+    rdat = read_yaml(p.parents[0] / "ranges" / "default.yml")
+    print(f"\n# {generators[p.parents[0].name]}\n")
+    ystr = yaml_traverse(ydat['_meta'], ydat, rdat, 2)
+    print(ystr)


### PR DESCRIPTION
(CC @SamYoules @soleyhyman @rosedshepherd)

For a while we've been struggling with the best way to document the YAML files - which is key as they contain all the defaults and parameters that people can map their data to - a handy well-formatted reference would be ideal.

@SamYoules found that all the existing solution for YAML => markdown or rst wouldn't work or  wouldn't do what we wanted so I've written a script myself as a prototype - `yamls_to_tables.py`

running this in the `strauss` environment will print a Markdown representation of the tables which could be output as a file, making use of in the `_meta` section docstrings we've been adding. In the `_meta` section, I also came up with a syntax for documenting the section and file as a whole. This is demonstrated in the Sampler YAML (`src/strauss/presets/sampler/default.yml`) which adds text to the top of the relevant section. All the parameters then get tabulated with their meta string, default value, default ranges and units

running `python yamls_to_tables.py` in the `strauss` top directory will print the markdown which can be copied or piped to clipboard, and displayed in a markdown viewer, e.g. [this](https://markdownlivepreview.com/). If this is viable, I'm hopeful we can add running this script into the documentation generation step, or even get sphinx to run it internally, which would be ideal. Note, github also does a good job rendering markdown, but we don't want to version control the output files of this - instead the documentation can be run on the fly from the existing YAML files. 

These files I think also make it a lot clearer to see where documentation is missing / insufficient for these parameters so should make finishing up. maintaining the documentation a lot easier. 