### PR TITLE
`audioop` sub-dependency management and `conda` streamlining

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,23 +2,7 @@ name: strauss
 channels:
   - anaconda
 dependencies:
-  - python=3.8
+  - python >= 3.6
   - pip
   - pip:
-    - jupyterlab
-    - ffmpeg_python
-    - ipython
-    - matplotlib
-    - numpy
-    - pandas
-    - pychord
-    - pyyaml
-    - scipy
-    - setuptools >= 4.2
-    - sf2utils
-    - sphinx
-    - tqdm
-    - TTS
-    - wavio
-    - wheel
-    - sounddevice
+    - -e ".[default]"

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
  wheel
  sounddevice
  sf2utils
+ audioop-lts; python_version >= "3.13"
 [options.packages.find]
 where = src
 [options.extras_require]


### PR DESCRIPTION
- Add conditional dependency on externally managed version of former core package dropped in py3.13, used by sf2utils (pending update to that package)
- Streamline `environment.yml` for `conda` install to install via `setup.cfg` so we only need to maintain 1 set of dependencies!