### PR TITLE
Initial editorial tweaks for JOSS paper

### DIFF
--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -16,7 +16,7 @@
 	journal={Data Sonification Archive},
 	author={Lenzi, Sara and Ciuccarelli, Paolo and Liu, Houjiang and Hua, Yuan and Zizzi, Nicole},
 	year={2021},
-	month={Jan}} 
+	month={Jan}}
 
 @article{Lindborg23,
 AUTHOR={Lindborg, PerMagnus  and Lenzi, Sara  and Chen, Manni },
@@ -43,8 +43,8 @@ ISSN={1664-1078}
             Harris, Charles R. and Archibald, Anne M. and
             Ribeiro, Ant{\^o}nio H. and Pedregosa, Fabian and
             {van Mulbregt}, Paul and {SciPy 1.0 Contributors}},
-  title   = {{{SciPy} 1.0: Fundamental Algorithms for Scientific
-            Computing in Python}},
+  title   = {{SciPy} 1.0: Fundamental Algorithms for Scientific
+            Computing in {Python}},
   journal = {Nature Methods},
   year    = {2020},
   volume  = {17},
@@ -111,7 +111,7 @@ archivePrefix = {arXiv},
 }
 
 @ARTICLE{Trayford23b,
-       author = {{Trayford}, James W. and {Harrison}, C.~M. and {Hinz}, R.~C. and {Kavanagh Blatt}, M. and {Dougherty}, S. and {Girdhar}, A.},
+       author = {{Trayford}, J. W. and {Harrison}, C.~M. and {Hinz}, R.~C. and {Kavanagh Blatt}, M. and {Dougherty}, S. and {Girdhar}, A.},
         title = "{Inspecting spectra with sound: proof-of-concept and extension to datacubes}",
       journal = {RAS Techniques and Instruments},
      keywords = {sonification, integral field spectroscopy, galaxies, data methods, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Astrophysics of Galaxies},
@@ -129,28 +129,42 @@ archivePrefix = {arXiv},
 }
 
 @inproceedings{Trayford23,
-author = {Trayford, James and Harrison, Chris},
+author = {Trayford, J. W. and Harrison, C.},
 year = {2023},
 month = {06},
 pages = {249-256},
-title = {Introducing strauss: A Flexible Sonification Python Package},
+title = {Introducing strauss: a flexible sonification {Python} package},
+booktitle = "{Proceedings of the 28th International Conference on Auditory Display (ICAD 2023)}",
+editor = {{Weger}, Marian and {Ziemer}, Tim and {R{\"o}nnberg}, Niklas},
 doi = {10.21785/icad2023.1978}
 }
 
 @ARTICLE{Trayford24,
-       author = {{Trayford}, J.~W. and {Youles}, S. and {Harrison}, C.~M. and {Bonne}, N.},
-        title = "{Ear to the Sky: Astronomical Sonification for Accessible Outreach, Education and Research with STRAUSS}",
-      journal = {\rmxaa},
+       author = {{Trayford}, J.~W. and {Youles}, S. and {Bonne}, N. and {Harrison}, C.~M.},
+        title = {Ear to the Sky: Astronomical Sonification for Accessible Outreach, Education and Research with {STRAUSS}},
+      journal = {Revista Mexicana de Astronom{\'i}a y Astrof{\'i}sica Serie de Conferencias},
      keywords = {Sonification, Multimodality, Data Analysis},
          year = 2024,
         month = jun,
        volume = {57},
-        pages = {42-46}
+        pages = {42-46},
+          url = {https://www.astroscu.unam.mx/rmaa/RMxAC..57/PDF/RMxAC..57_jtrayford-X.pdf}
 }
 
 
 
-@article{Casado24, doi = {10.21105/joss.05819}, url = {https://doi.org/10.21105/joss.05819}, year = {2024}, publisher = {The Open Journal}, volume = {9}, number = {93}, pages = {5819}, author = {Johanna Casado and Gonzalo de la Vega and Beatriz García}, title = {SonoUno development: a User-Centered Sonification software for data analysis}, journal = {Journal of Open Source Software} }
+@article{Casado24,
+      doi = {10.21105/joss.05819},
+      url = {https://doi.org/10.21105/joss.05819},
+     year = {2024},
+publisher = {The Open Journal},
+   volume = {9},
+   number = {93},
+    pages = {5819},
+   author = {Johanna Casado and Gonzalo de la Vega and Beatriz García},
+    title = {SonoUno development: a User-Centered Sonification software for data analysis},
+  journal = {Journal of Open Source Software}
+}
 
 @software{Brasseur23,
   author       = {Brasseur, Clara and
@@ -191,7 +205,7 @@ doi = {10.21785/icad2023.1978}
 @ARTICLE{Turk11,
    author = {{Turk}, M.~J. and {Smith}, B.~D. and {Oishi}, J.~S. and {Skory}, S. and
      {Skillman}, S.~W. and {Abel}, T. and {Norman}, M.~L.},
-    title = "{yt: A Multi-code Analysis Toolkit for Astrophysical Simulation Data}",
+    title = {{yt}: A Multi-code Analysis Toolkit for Astrophysical Simulation Data},
   journal = {The Astrophysical Journal Supplement Series},
 archivePrefix = "arXiv",
    eprint = {1011.3514},

--- a/joss/paper.md
+++ b/joss/paper.md
@@ -43,7 +43,7 @@ _Sonification_, or conveying data using non-verbal audio, is a relatively niche
 but growing approach for presenting data across multiple specialist
 domains including  astronomy, climate science, and beyond [@Lenzi21;
 @Zanella22; @Lindborg23]. The
-`strauss` Python package aims to provide such a tool, which builds upon previous
+`strauss` Python package aims to provide such a tool that builds upon previous
 approaches to provide a powerful means to explore different ways of expressing
 data, with fine control over the output audio and its format.
 `strauss` is a free, open source (FOSS) Python package, designed to allow flexible and
@@ -54,7 +54,7 @@ The remit of `strauss` is broad; it is intended to be able to bridge between
 _ad-hoc_ solutions for sonifying very particular datasets, and highly technical compositional
 and sound-design tools that are not optimised for sonification, or may have a steep
 learning curve. The code offers a range of approaches to sonification for a variety of
-contexts (e.g. science education, science communication, technical data analysis, etc). 
+contexts (e.g. science education, science communication, technical data analysis, etc.).
 To this end, `strauss` is packaged with a number of examples of different sonification
 approaches, and preset configurations to support a _low-barrier, high-ceiling_ approach.
 `strauss` has been used to produce both educational resources [@Harrison22], and
@@ -65,8 +65,8 @@ analysis tools [@Trayford23b].
 Sonification has great potential as a fundamental approach for interfacing with data.
 This provides new perspectives on data that complement visual approaches, as
 well as an accessible channel to data for those who cannot access visual
-presentation, for example those who are blind or visually impaired
-(BVI). As with the dominant approach of data 
+presentation, e.g. those who are blind or visually impaired
+(BVI). As with the dominant approach of data
 _visualisation_, what can constitute sonification is very broad, with different considerations for aspects
 such as the audience, information content and aesthetics of the sonification. In
 order for sonification to become more established and realise its potential as
@@ -75,17 +75,17 @@ sonification intuitive and accessible to those who routinely work with data.
 
 Unlike data _visualisation_, however, sonification of data is a far less developed
 methodology, with a lack of widely adopted, cross-domain tools and interfaces for those dealing with data
-to use. For example, in the Python programming language, a number of packages
-exist for visualising data, such as `matplotlib` [@Hunter07], `yt` [@Turk11],
-`seaborn` [@Waskom21], or `plotly` [@plotly]. The lack of dedicated and accessible
+to use. E.g., in the Python programming language, a number of packages
+exist for visualising data, such as Matplotlib [@Hunter07], yt [@Turk11],
+seaborn [@Waskom21], or Plotly [@plotly]. The lack of dedicated and accessible
 tools for sonifying data is a barrier to exploring the approach. Most solutions
 are piecemeal, using _ad-hoc_ tools to parse data and map it to properties of sound as
-well as generating and outputting sound in different formats. What's more, many 
+well as generating and outputting sound in different formats. What's more, many
 of the tools being repurposed to sonify data are proprietary and platform-dependent, requiring
 paid-for licenses.
 
-A number of effective python packages for data sonification have emerged e.g. `astronify`
-[@Brasseur23] and `SonoUno` [@Casado24]. However these are typically feature-limited
+A number of effective python packages for data sonification have emerged, e.g. `astronify`
+[@Brasseur23] and `SonoUno` [@Casado24], but these are typically feature-limited
 in how sonification is produced, namely continuous pitch-mapped sonification.
 
 Realising the potential of sonification may require a "crowdsourced" approach; via
@@ -93,14 +93,14 @@ broad adoption of the technique and innovation in sonification approaches driven
 the scientific community. In this context, we identify a need for Python package that:
 
 - Provides a full pipeline from data to sonified audio that can be integrated into the
-workflows of scientists and data analysts
+workflows of scientists and data analysts.
 
 - Is modular and enables complex, multi-variate sonification to be produced and fine tuned,
 while being simple enough to produce simple sonifications, for instance for novice users or
-in educational contexts
+in educational contexts.
 
 - Is fully open-source and platform-independent, such that sonification is able to be
-integrated more broadly into scientific practice
+integrated more broadly into scientific practice.
 
 `strauss` (**S**onification **T**ools and **R**esources for **A**nalysis **U**sing
 **S**ound **S**ynthesis) is a Python package for data sonification. The code uses an
@@ -110,7 +110,7 @@ analysts to fully sonify their data in a way analogous to a plotting pipeline, t
 analysed independently or in conjunction with visuals.
 
 By choosing the mapping between the variables being communicated and the expressive properties
-of sound, `strauss` is designed to be a _low-barrier, high ceiling_ tool; providing
+of sound, `strauss` is designed to be a _low-barrier, high-ceiling_ tool; providing
 the means to make diverse and highly customised sonifications with a high degree of
 low-level control as the user becomes more experienced, while providing a relatively
 simple path to produce sonifications quickly for a novice. This is intended to
@@ -120,20 +120,20 @@ how to express data with sound.
 
 The `strauss` code minimises dependencies where possible, implementing built-in signal
 generation and audio parsing and encoding based on low-level python libraries like
-`numpy` [@numpy] and `scipy` [@scipy], as well as being tested on multiple platforms (_MacOS, Linux,
-Windows_). This also provides means to interface with commonly used audio formats,
+NumPy [@numpy] and SciPy [@scipy], as well as being tested on multiple platforms (MacOS, Linux,
+Windows). This also provides means to interface with commonly used audio formats,
 such as _"Soundfont"_ files (`.sf2`) to open a range of possibilities for representing
 data using different instruments. This helps to ensure that the free and open source
 status of `strauss` is maintained and does not require difficult to install or
 proprietary software, that may themselves have steep learning curves.
 
-Towards our _low barrier_ aspirations for `strauss`, a Tutorial-driven development (TDD)
+Towards our _low-barrier_ aspirations for `strauss`, a tutorial-driven development (TDD)
 approach is used where each major feature should have an associated tutorial example,
 which are packaged with the code, in both Python Notebook (`examples/.ipynb`) and Python script
 (`examples/*.py`) formats. `strauss` provides tools for inline playback of sound in both formats.
 In addition, a further collection of modified examples is provided specifically for the
 _Google Colab_ platform (`examples/colab/*.ipynb`), allowing examples to be run fully
-in-browser without requiring a local install of the code. 
+in-browser without requiring a local install of the code.
 
 Offering both formats for examples in `strauss` allows us to exploit the interactivity
 and low technical threshold needed to use notebooks, while also having the BVI accessibility


### PR DESCRIPTION
This is an initial set of editorial tweaks to the JOSS paper following the [successful review](https://github.com/openjournals/joss-reviews/issues/7875). I believe these are all quite minor but you should review the changes to check I haven't changed any meaning anywhere.

I'll also note that the name of the package is generally set in lower case monospace (i.e., `strauss`). Though we can't have monospace in the title of the paper, I'd suggest changing it to lower case text (i.e., from "STRAUSS" to "strauss") for a more consistent appearance. If you do change the title, you'll need to update the Zenodo archive to match. You can change the Zenodo deposit metadata without creating a new archive.

Once these changes are merged (and maybe the title changed) I'll do another test run of the publication pipeline.