### PR TITLE
Soundfont fix

### DIFF
--- a/examples/AudioCaption.ipynb
+++ b/examples/AudioCaption.ipynb
@@ -18,8 +18,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext autoreload \n",
-    "%autoreload 2\n",
     "from strauss.sonification import Sonification\n",
     "from strauss.sources import Events\n",
     "from strauss import channels\n",
@@ -277,7 +275,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/DaySequence.ipynb
+++ b/examples/DaySequence.ipynb
@@ -23,9 +23,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext autoreload \n",
-    "%autoreload 2\n",
-    "import ffmpeg as ff\n",
     "import wavio as wav\n",
     "from strauss.sonification import Sonification\n",
     "from strauss.sources import Objects\n",
@@ -287,7 +284,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/EarthSystem.ipynb
+++ b/examples/EarthSystem.ipynb
@@ -23,10 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext autoreload \n",
-    "%autoreload 2\n",
     "import matplotlib.pyplot as plt\n",
-    "import ffmpeg as ff\n",
     "import wavio as wav\n",
     "from strauss.sonification import Sonification\n",
     "from strauss.sources import Objects\n",
@@ -192,7 +189,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/LightCurveSoundfonts.ipynb
+++ b/examples/LightCurveSoundfonts.ipynb
@@ -27,8 +27,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext autoreload \n",
-    "%autoreload 2\n",
     "import matplotlib.pyplot as plt\n",
     "from strauss.sonification import Sonification\n",
     "from strauss.sources import Objects, Events\n",

--- a/examples/LightCurveSoundfonts.ipynb
+++ b/examples/LightCurveSoundfonts.ipynb
@@ -76,8 +76,8 @@
     "    # path = os.path.realpath(outdir)\n",
     "    \n",
     "    files = (\"guitars.sf2\", \"flute.sf2\")\n",
-    "    urls = (\"https://drive.google.com/uc?export=download&id=18CCYj8AFy7wpDdGg0ADx8GfTTHEFilrs\",\n",
-    "           \"https://drive.google.com/uc?export=download&id=1DAbIitPRUUGidrhVt4wiwwXrSxOD7RDY\")\n",
+    "    urls = (\"https://huggingface.co/datasets/projectlosangeles/soundfonts4u/resolve/main/Guitars-Universal-V1.5.sf2\",\n",
+    "           \"https://huggingface.co/datasets/projectlosangeles/soundfonts4u/resolve/main/Expressive%20Flute%20SSO-v1.2.sf2\")\n",
     "    for f, u in zip(files, urls):\n",
     "        with urllib.request.urlopen(u) as response, Path(f\"{path}\",f\"{f}\").open(mode='wb') as out_file:\n",
     "            print(f\"\\t getting {f}\")\n",
@@ -139,7 +139,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sf_preset = 19\n",
+    "sf_preset = 49\n",
     "guitar_sampler= Sampler(Path(outdir, \"guitars.sf2\"), sf_preset=sf_preset)"
    ]
   },
@@ -299,7 +299,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/LightCurveSoundfonts.py
+++ b/examples/LightCurveSoundfonts.py
@@ -41,8 +41,8 @@ else:
     path = str(path)
     
     files = ("guitars.sf2", "flute.sf2")
-    urls = ("https://drive.google.com/uc?export=download&id=18CCYj8AFy7wpDdGg0ADx8GfTTHEFilrs",
-           "https://drive.google.com/uc?export=download&id=1DAbIitPRUUGidrhVt4wiwwXrSxOD7RDY")
+    urls = ("https://huggingface.co/datasets/projectlosangeles/soundfonts4u/resolve/main/Guitars-Universal-V1.5.sf2",
+           "https://huggingface.co/datasets/projectlosangeles/soundfonts4u/resolve/main/Expressive%20Flute%20SSO-v1.2.sf2")
     for f, u in zip(files, urls):
         with urllib.request.urlopen(u) as response, Path(f"{path}",f"{f}").open(mode='wb') as out_file:
             print(f"\t getting {f}")
@@ -67,7 +67,7 @@ guitar_sampler = Sampler(Path(outdir, "guitars.sf2"))
 # This can be useful to inspect whats inside the soundfont file. If we already know which preset we want (by e.g. inspecting this list), we can pick the preset ahead of time, using the `sf_preset` keyword argument:
 
 
-sf_preset = 19
+sf_preset = 49
 guitar_sampler= Sampler(Path(outdir,"flute.sf2"), sf_preset=sf_preset)
 
 

--- a/examples/PlanetaryOrbits.ipynb
+++ b/examples/PlanetaryOrbits.ipynb
@@ -23,10 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext autoreload \n",
-    "%autoreload 2\n",
     "import matplotlib.pyplot as plt\n",
-    "import ffmpeg as ff\n",
     "import wavio as wav\n",
     "from strauss.sonification import Sonification\n",
     "from strauss.sources import Objects\n",
@@ -268,7 +265,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/SonifyingData1D.ipynb
+++ b/examples/SonifyingData1D.ipynb
@@ -23,8 +23,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext autoreload \n",
-    "%autoreload 2\n",
     "import matplotlib.pyplot as plt\n",
     "from strauss.sonification import Sonification\n",
     "from strauss.sources import Objects\n",
@@ -275,7 +273,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/SpectralData.ipynb
+++ b/examples/SpectralData.ipynb
@@ -23,8 +23,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext autoreload \n",
-    "%autoreload 2\n",
     "import matplotlib.pyplot as plt\n",
     "from strauss.sonification import Sonification\n",
     "from strauss.sources import Events, Objects\n",
@@ -318,7 +316,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/StarsAppearing.ipynb
+++ b/examples/StarsAppearing.ipynb
@@ -23,10 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext autoreload \n",
-    "%autoreload 2\n",
     "import matplotlib.pyplot as plt\n",
-    "import ffmpeg as ff\n",
     "import wavio as wav\n",
     "from strauss.sonification import Sonification\n",
     "from strauss.sources import Events\n",
@@ -219,7 +216,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/colab/AudioCaption.ipynb
+++ b/examples/colab/AudioCaption.ipynb
@@ -88,8 +88,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext autoreload \n",
-    "%autoreload 2\n",
     "from strauss.sonification import Sonification\n",
     "from strauss.sources import Events\n",
     "from strauss import channels\n",
@@ -347,7 +345,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/colab/DaySequence.ipynb
+++ b/examples/colab/DaySequence.ipynb
@@ -85,10 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext autoreload \n",
-    "%autoreload 2\n",
     "import matplotlib.pyplot as plt\n",
-    "import ffmpeg as ff\n",
     "import wavio as wav\n",
     "from strauss.sonification import Sonification\n",
     "from strauss.sources import Objects\n",
@@ -355,7 +352,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/colab/EarthSystem.ipynb
+++ b/examples/colab/EarthSystem.ipynb
@@ -85,10 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext autoreload \n",
-    "%autoreload 2\n",
     "import matplotlib.pyplot as plt\n",
-    "import ffmpeg as ff\n",
     "import wavio as wav\n",
     "from strauss.sonification import Sonification\n",
     "from strauss.sources import Objects\n",
@@ -261,7 +258,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/colab/LightCurveSoundfonts.ipynb
+++ b/examples/colab/LightCurveSoundfonts.ipynb
@@ -89,8 +89,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext autoreload \n",
-    "%autoreload 2\n",
     "import matplotlib.pyplot as plt\n",
     "from strauss.sonification import Sonification\n",
     "from strauss.sources import Objects, Events\n",

--- a/examples/colab/LightCurveSoundfonts.ipynb
+++ b/examples/colab/LightCurveSoundfonts.ipynb
@@ -138,8 +138,8 @@
     "    # path = os.path.realpath(outdir)\n",
     "    \n",
     "    files = (\"guitars.sf2\", \"flute.sf2\")\n",
-    "    urls = (\"https://drive.google.com/uc?export=download&id=18CCYj8AFy7wpDdGg0ADx8GfTTHEFilrs\",\n",
-    "           \"https://drive.google.com/uc?export=download&id=1DAbIitPRUUGidrhVt4wiwwXrSxOD7RDY\")\n",
+    "    urls = (\"https://huggingface.co/datasets/projectlosangeles/soundfonts4u/resolve/main/Guitars-Universal-V1.5.sf2\",\n",
+    "           \"https://huggingface.co/datasets/projectlosangeles/soundfonts4u/resolve/main/Expressive%20Flute%20SSO-v1.2.sf2\")\n",
     "    for f, u in zip(files, urls):\n",
     "        with urllib.request.urlopen(u) as response, Path(f\"{path}\",f\"{f}\").open(mode='wb') as out_file:\n",
     "            print(f\"\\t getting {f}\")\n",
@@ -201,7 +201,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sf_preset = 19\n",
+    "sf_preset = 49\n",
     "guitar_sampler= Sampler(Path(outdir, \"guitars.sf2\"), sf_preset=sf_preset)"
    ]
   },
@@ -361,7 +361,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/colab/PlanetaryOrbits.ipynb
+++ b/examples/colab/PlanetaryOrbits.ipynb
@@ -85,10 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext autoreload \n",
-    "%autoreload 2\n",
     "import matplotlib.pyplot as plt\n",
-    "import ffmpeg as ff\n",
     "import wavio as wav\n",
     "from strauss.sonification import Sonification\n",
     "from strauss.sources import Objects\n",
@@ -329,7 +326,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/colab/SonifyingData1D.ipynb
+++ b/examples/colab/SonifyingData1D.ipynb
@@ -85,8 +85,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext autoreload \n",
-    "%autoreload 2\n",
     "import matplotlib.pyplot as plt\n",
     "from strauss.sonification import Sonification\n",
     "from strauss.sources import Objects\n",
@@ -353,7 +351,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/colab/SpectralData.ipynb
+++ b/examples/colab/SpectralData.ipynb
@@ -85,8 +85,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext autoreload \n",
-    "%autoreload 2\n",
     "import matplotlib.pyplot as plt\n",
     "from strauss.sonification import Sonification\n",
     "from strauss.sources import Events, Objects\n",
@@ -379,7 +377,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/colab/StarsAppearing.ipynb
+++ b/examples/colab/StarsAppearing.ipynb
@@ -85,10 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%reload_ext autoreload \n",
-    "%autoreload 2\n",
     "import matplotlib.pyplot as plt\n",
-    "import ffmpeg as ff\n",
     "import wavio as wav\n",
     "from strauss.sonification import Sonification\n",
     "from strauss.sources import Events\n",
@@ -281,7 +278,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = strauss
-version = 1.0.2
+version = 1.0.3
 author = James Trayford
 author_email = james.trayford@port.ac.uk
 description = Sonification Tools and Resources for Astronomers Using Sound Synthesis

--- a/src/strauss/__init__.py
+++ b/src/strauss/__init__.py
@@ -13,4 +13,4 @@ from . import sources
 from . import stream
 from . import presets
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"


### PR DESCRIPTION
A couple of things 

1. Changing the download links for the _Soundfont_ files in the example notebook to an archive link on _Hugging Face_ for now - probably should find some links on internet archive longer term?
2. Strip `autoreload` extensions as these seem to fail in _Colab_ now due toy python 3.12 removing the `imp` library. These can be useful for development locally (changing code in `strauss` core modules), but not useful in _Colab_ notebooks. Also took this out of local notebooks for 3.12 compatibility. 
3. increment subminor version (`1.0.3`)