### PR TITLE
Panning, mapping validation, new `map_lims` defaults and spatial angles special case

### DIFF
--- a/src/strauss/sonification.py
+++ b/src/strauss/sonification.py
@@ -157,7 +157,7 @@ class Sonification:
 
             # index note properties
             t = self.sources.mapping['time'][source]
-            tsamp = int(Nsamp * t)
+            tsamp = int((Nsamp-1) * t)
             chord = self.score.note_sequence[cbin[source]]
             nints = self.score.nintervals[cbin[source]]
             pitch = pitchfrac[source]

--- a/src/strauss/sonification.py
+++ b/src/strauss/sonification.py
@@ -174,18 +174,24 @@ class Sonification:
             # run generator to play each note
             sstream = self.generator.play(sourcemap)
             playlen = sstream.values.size
-            if 'phi' in sourcemap:
-                azi     = const_or_evo(sourcemap['phi'], sstream.sampfracs) * 2 * np.pi
-            elif 'azimuth' in sourcemap:
-                azi     = const_or_evo(sourcemap['azimuth'], sstream.sampfracs) * 2 * np.pi
+
+            # place source on listener plane (quarter rotation) by default
+            polar = 0.5 * np.pi
+            if 'pan' in sourcemap:
+                # in pan mode, put everything on the 
+                azi     = (const_or_evo(sourcemap['pan'], sstream.sampfracs) + 0.5) * np.pi
             else:
-                azi     = const_or_evo(self.generator.preset['azimuth'], sstream.sampfracs) * 2 * np.pi
-            if 'theta' in sourcemap:
-                polar   = const_or_evo(sourcemap['theta'], sstream.sampfracs) * np.pi
-            elif 'polar' in sourcemap:
-                polar   = const_or_evo(sourcemap['polar'], sstream.sampfracs) * np.pi                
-            else:
-                polar   = const_or_evo(self.generator.preset['polar'], sstream.sampfracs) * np.pi
+                # TODO: generic handling of alias parameters (beyond 3D angles)
+                if 'phi' in sourcemap:
+                    azi     = const_or_evo(sourcemap['phi'], sstream.sampfracs) * 2 * np.pi
+                elif 'azimuth' in sourcemap:
+                    azi     = const_or_evo(sourcemap['azimuth'], sstream.sampfracs) * 2 * np.pi
+                else:
+                    azi     = const_or_evo(self.generator.preset['azimuth'], sstream.sampfracs) * 2 * np.pi
+                if 'theta' in sourcemap:
+                    polar   = const_or_evo(sourcemap['theta'], sstream.sampfracs) * np.pi
+                elif 'polar' in sourcemap:
+                    polar   = const_or_evo(sourcemap['polar'], sstream.sampfracs) * np.pi                
 
             # compute sample indices for truncating notes overshooting sonification length
             trunc_note = min(playlen, lastsamp-tsamp)

--- a/src/strauss/sources.py
+++ b/src/strauss/sources.py
@@ -38,6 +38,7 @@ mappable = ['polar',
             'time_evo',
             'spectrum',
             'pitch_shift',
+            'pan',
             'volume_envelope/A',
             'volume_envelope/D',
             'volume_envelope/S',
@@ -57,6 +58,7 @@ evolvable = ['polar',
              'cutoff',
              'time_evo',
              'pitch_shift',
+             'pan'
              'volume_lfo/freq_shift',
              'volume_lfo/amount',
              'pitch_lfo/freq_shift',
@@ -72,6 +74,7 @@ param_limits = [(0,1),#np.pi),
                 (0,1),
                 (0,1),
                 (0,24),
+                (0,1),
                 (1e-2, 10),
                 (1e-2, 10),
                 (0,1),
@@ -84,6 +87,16 @@ param_limits = [(0,1),#np.pi),
                 (0,2)]     
 
 param_lim_dict = dict(zip(mappable, param_limits))
+
+# parameter pairs that don't work together
+invalid_combos = {('azimuth', 'pan') : 'angle_pan', 
+                  ('polar', 'pan') :  'angle_pan',
+                  ('phi', 'pan'): 'angle_pan',
+                  ('theta', 'pan'): 'angle_pan',
+                  ('theta', 'azimuth'): 'alias',
+                  ('phi', 'polar'): 'alias'}
+invalid_explanations = {'angle_pan': "'pan' and spatial angles are both controlling spatialisation",
+                        'alias': "these represent different names for the same quantity"}
 
 class Source:
     """ Generic source class defining common methods/attributes
@@ -107,38 +120,65 @@ class Source:
     Raises:
     	UnrecognisedProperty: if `mapped_quantities` entry not in `mappable`.
     """
-    def __init__(self, mapped_quantities):
+    def __init__(self, mapped_quantities, angle_unit=None):
         """
         Args:
     	  mapped_quantities (:obj:`list(str)`): The subset of parameters to
     	    which data will be mapped.
         """
-        # check these are all mappable parameters
 
+        self.angle_unit = angle_unit
+        
+        # check these are all mappable parameters
         
         for q in mapped_quantities:
             if q not in mappable:
                 raise UnrecognisedProperty(
                     f"Property \"{q}\" is not recognised")
-
-        if ('theta' in mapped_quantities) and ('polar' in mapped_quantities):
-            raise Exception(
-                "\"theta\" and \"polar\" cannot be combined as " \
-                "these represent the same quantity: \"theta\" and " \
-                "\"phi\" are deprecated and will be replaced with \"polar\"" \
-                " and \"azimuth\" in a future version.")
-
-        if ('phi' in mapped_quantities) and ('azimuth' in mapped_quantities):
-            raise Exception(
-                "\"phi\" and \"azimuth\" cannot be combined as " \
-                "these represent the same quantity: \"theta\" and " \
-                "\"phi\" are deprecated and will be replaced with \"polar\"" \
-                " and \"azimuth\" in a future version.")            
             
         # initialise common structures
         self.mapped_quantities = mapped_quantities
         self.raw_mapping = {}
         self.mapping = {}
+
+    def validate_mapping(self):
+        """ Validate the mapping choices, warn and/or except on issues.
+
+        Looks through provided mapping for invalid combinations of parameters,
+        as well as checking angle unit for the special case of 3D angles
+        """
+
+        params = self.mapped_quantities
+        err_text = ""
+        warn_text = ""
+        
+        # check invalid combinations of parameters
+        bad_combos = []
+        explain = []        
+        for pair in invalid_combos.keys():
+            if (pair[0] in params) and (pair[1] in params):
+                bad_combos.append(pair)
+                explain.append(invalid_explanations[invalid_combos[pair]])
+        if bad_combos:
+            err_text += "\n\nInvald parameter combinations in mapping:\n"
+            for i in range(len(bad_combos)):
+                err_text += f" - '{bad_combos[i][0]}' and '{bad_combos[i][1]}' "
+                err_text += f"are incompatible, as {explain[i]}. \n"
+            err_text += f"Please remove any incompatible parameter combinations from the input mapping."
+
+        # check we know what unit angles are input in
+        for ang in ('azimuth', 'polar', 'theta', 'phi'):
+            if (ang in params) and not (ang in self.map_lims) and not (self.angle_unit):
+                warn_text += f" - no angle unit or map_lims entry for {ang}, assuming [0,1] range \n"
+            if (ang in self.map_lims) and (self.angle_unit):
+                warn_text += f" - map_lims entry for '{ang}' ('{ang}':{self.map_lims['ang']}) provided alongside "
+                warn_text += f"angle_unit={self.angle_unit}. Ignoring angle_unit for '{ang}'.\n"
+                
+        # Finally, warn or except about any issues after full audit of mapping
+        if warn_text:
+            warnings.warn("\n\nParameter mapping warning:\n"+warn_text)
+        if err_text:
+            raise Exception(err_text)
         
     def apply_mapping_functions(self, map_funcs={}, map_lims={}, param_lims={}):
         """ Taking input data and mapping to parameters.
@@ -180,6 +220,14 @@ class Source:
         
         """
 
+        # first store the chosen mapping variables
+        self.map_funcs = map_funcs
+        self.map_lims = map_lims
+        self.param_lims = param_lims
+
+        # then validate the mapping combinations
+        self.validate_mapping()
+        
         # set up dictionaries to store the limits
         self.lims = {}
         self.plims = {}
@@ -197,7 +245,7 @@ class Source:
             if key in map_lims:
                 vallims = map_lims[key]
             else:
-                vallims = (0,1)
+                vallims = ('0%','100%')
 
             # set parameter limits if specified
             if key in param_lims:

--- a/src/strauss/sources.py
+++ b/src/strauss/sources.py
@@ -24,6 +24,7 @@ import numpy as np
 import pandas as pd
 from scipy.interpolate import interp1d
 import matplotlib.pyplot as plt
+from scipy import signal as sig
 from .utilities import rescale_values 
 import warnings
 
@@ -88,6 +89,13 @@ param_limits = [(0,1),#np.pi),
 
 param_lim_dict = dict(zip(mappable, param_limits))
 
+
+spatial_angles = ('azimuth', 'polar', 'theta', 'phi')
+z_angles = ('polar', 'theta')
+angle_unit_maxs = {'degrees': 360,
+                   'radians': 2*np.pi,
+                   'cycles': 1}
+
 # parameter pairs that don't work together
 invalid_combos = {('azimuth', 'pan') : 'angle_pan', 
                   ('polar', 'pan') :  'angle_pan',
@@ -120,14 +128,12 @@ class Source:
     Raises:
     	UnrecognisedProperty: if `mapped_quantities` entry not in `mappable`.
     """
-    def __init__(self, mapped_quantities, angle_unit=None):
+    def __init__(self, mapped_quantities):
         """
         Args:
     	  mapped_quantities (:obj:`list(str)`): The subset of parameters to
     	    which data will be mapped.
         """
-
-        self.angle_unit = angle_unit
         
         # check these are all mappable parameters
         
@@ -149,27 +155,33 @@ class Source:
         """
 
         params = self.mapped_quantities
-        err_text = ""
+        errs = []
         warn_text = ""
         
         # check invalid combinations of parameters
         bad_combos = []
-        explain = []        
+        explain = []
         for pair in invalid_combos.keys():
             if (pair[0] in params) and (pair[1] in params):
                 bad_combos.append(pair)
                 explain.append(invalid_explanations[invalid_combos[pair]])
         if bad_combos:
-            err_text += "\n\nInvald parameter combinations in mapping:\n"
+            err_text = "Invald parameter combinations in mapping:\n"
             for i in range(len(bad_combos)):
                 err_text += f" - '{bad_combos[i][0]}' and '{bad_combos[i][1]}' "
                 err_text += f"are incompatible, as {explain[i]}. \n"
-            err_text += f"Please remove any incompatible parameter combinations from the input mapping."
+            err_text += f"Please remove any incompatible parameter combinations from the input mapping.\n\n"
+            errs.append(err_text)
 
         # check we know what unit angles are input in
-        for ang in ('azimuth', 'polar', 'theta', 'phi'):
+        for ang in spatial_angles:
+            if ang in self.param_lims:
+                err_text = f"As spatial angle {ang} is cyclic, a limited range cannot be supported in param_lims. "
+                err_text += f"Instead, provide the units of input values for {ang} using the angle_unit argument via"
+                err_text += f"of apply_mapping_functions, or use the 'pan' parameter to simply map stereo effects.\n\n"
+                err_text.append(err_text)
             if (ang in params) and not (ang in self.map_lims) and not (self.angle_unit):
-                warn_text += f" - no angle unit or map_lims entry for {ang}, assuming [0,1] range \n"
+                warn_text += f" - no angle unit or map_lims entry for {ang}, assuming values (0,1] for fractions of a circle (cycles)  \n"
             if (ang in self.map_lims) and (self.angle_unit):
                 warn_text += f" - map_lims entry for '{ang}' ('{ang}':{self.map_lims['ang']}) provided alongside "
                 warn_text += f"angle_unit={self.angle_unit}. Ignoring angle_unit for '{ang}'.\n"
@@ -177,10 +189,16 @@ class Source:
         # Finally, warn or except about any issues after full audit of mapping
         if warn_text:
             warnings.warn("\n\nParameter mapping warning:\n"+warn_text)
-        if err_text:
-            raise Exception(err_text)
+        if len(errs):
+            err_text = ''
+            errnum = 1
+            for e in errs:
+                err_text += f"{errnum}.  "
+                err_text += e
+                errnum += 1
+            raise Exception(f"Found {len(errs)} critical issues with mapping:\n\n", err_text)
         
-    def apply_mapping_functions(self, map_funcs={}, map_lims={}, param_lims={}):
+    def apply_mapping_functions(self, map_funcs={}, map_lims={}, param_lims={}, angle_unit=None):
         """ Taking input data and mapping to parameters.
 
         This function does the bulk of the work for `Source` classes,
@@ -212,19 +230,27 @@ class Source:
         	map_lims ranges are resaled to these ranges to give
         	the parameter values. If not provided, the default
         	param_lim_dict values are taken.
-
+           angle_unit (:obj:`str`, optional): string naming a
+                supported unit for any spatial angles used in the mapping
+          	(e.g. `'azimuth'` or `'polar'`). Supported units are
+        	`'degrees'`, `'radians'` or `'cycles'`. If spatial
+        	angles are mapped without any unit system, will default
+        	to cycles and warn the user.
+        	
+        
         Note:
            There is special behaviour for the `polar` and `azimuth`
            parameters, to ensure shortest angular distance when
            interpolating across the 0-2pi and 0-pi boundaries.
-        
+                   
         """
 
         # first store the chosen mapping variables
         self.map_funcs = map_funcs
         self.map_lims = map_lims
         self.param_lims = param_lims
-
+        self.angle_unit = angle_unit
+        
         # then validate the mapping combinations
         self.validate_mapping()
         
@@ -244,9 +270,23 @@ class Source:
             # set mapping limits if specified
             if key in map_lims:
                 vallims = map_lims[key]
+            elif key in spatial_angles:
+                # special case for spatial angles - use absolute values
+                # set domain based on units unit (by default in cycles)
+                amax = 1
+                if self.angle_unit:
+                    amax = angle_unit_maxs[self.angle_unit]
+                # for angles make sure conforms to units
+                if key in z_angles:
+                    # triangle wave behaviour to map polar angle domain
+                    mapvals = (sig.sawtooth(2*np.pi*(mapvals/amax),0.5) + 1)/2
+                else:
+                    # sawtooth wave behaviour to map azimuthal angle domain
+                    mapvals = (mapvals%amax)/amax
+                vallims = (0, 1)
             else:
                 vallims = ('0%','100%')
-
+                
             # set parameter limits if specified
             if key in param_lims:
                 plims = param_lims[key]
@@ -302,7 +342,6 @@ class Source:
                 # ^ in case we want to catch and pre process multi-spectra
                 continue
             elif hasattr(self.mapping[key][0], "__iter__"):
-                # print(key, self.mapping[key][0])
                 for i in range(self.n_sources):
                     if key not in evolvable:
                         raise Exception(f"Mapping error: Parameter \"{key}\" cannot be evolved.")

--- a/tests/pre-merge/DemoFeatures.ipynb
+++ b/tests/pre-merge/DemoFeatures.ipynb
@@ -201,9 +201,8 @@
     "#generator = guitar_sampler\n",
     "generator = copy.copy(synth)\n",
     "\n",
-    "lightcurve = np.genfromtxt(Path('..', 'data', 'datasets', '55Cancri_lc.dat'))\n",
-    "x = lightcurve[:,0][:]\n",
-    "y = lightcurve[:,1][:]\n",
+    "x = np.linspace(0,100,400)\n",
+    "y =np.log10( np.sin(x) +1.05)\n",
     "\n",
     "notes = [[\"C3\",\"D3\",\"E3\",\"G3\",\"B3\",\"C4\",\"D4\",\"E4\",\"G4\",\"B4\",\"C5\",\"D5\",\"E5\",\"G5\",\"B5\"]]\n",
     "score =  Score(notes, 15)\n",
@@ -270,6 +269,14 @@
    "source": [
     "Now an `Objects` sonification"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5525f33-7f23-453e-91b1-2d3ed0e256fb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -448,6 +455,14 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b16304df-dc08-4e83-9012-1dd361eb90ad",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "id": "G6p6kTjjknBq",
    "metadata": {
@@ -478,6 +493,177 @@
    "source": [
     "sampler = Sampler(Path(\"..\", \"data\", \"samples\", \"glockenspiels\"))\n",
     "sampler.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23a041f7-dc95-49a1-a02c-368b81d2f891",
+   "metadata": {},
+   "source": [
+    "### <u> Mapping Defaults</u> "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9058c427-dee7-44f6-a1c9-b7295d4596f2",
+   "metadata": {},
+   "source": [
+    "Changed the default `map_lims` range from `[0,1]` to `['0%','100%']`: this means by default sound parameters adapt to the offgset and range of the data.\n",
+    "\n",
+    "The only exceptions to this are 3D spatial angles (e.g. `'polar'` and `'azimuth'`), which use an absolute unit system due to their cyclic nature. As 3D spatial mapping is relatively advanced, we also institute a new `'pan'` parameter, ranging from fully left to fully right, which can uses the same `['0%','100%']` defaults as other properties.\n",
+    "\n",
+    "To demonstrate, we set up a generator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f0c7b56-bbbe-4ae6-b968-8052c0fb9ab5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "synth = Synthesizer()\n",
+    "synth.load_preset('pitch_mapper')\n",
+    "# manually set note properties to get a suitable sound\n",
+    "synth.modify_preset({'note_length':0.03, # hold each note for 0.03 seconds or 30 ms - what if this was 1s?\n",
+    "                         'volume_envelope': {'use':'on', 'A':0.01,'R':0.07}}) # ✏️ Time to fade out once note is released, using 100 ms"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f608abf1-e1a7-4637-a084-1a884e25986e",
+   "metadata": {},
+   "source": [
+    "and some fake data, notably with offset and scaling relative to a `[0,1]` range"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0111bdc4-ad20-4150-99b1-0ed0d68b38c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "yoffset = -700\n",
+    "xscale = 100\n",
+    "\n",
+    "x = np.linspace(0,xscale,200)\n",
+    "y =np.log10( np.sin(60*x/scale) +1.01) + yoffset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7323e8cd-8935-4501-8bbe-2807004e9e2a",
+   "metadata": {},
+   "source": [
+    "and then use an `Event` sonification, with a periodic `y` value mapped to `pitch` and additionally mapping `x` to `pan`. This shows a sonification that is unaffected by offsets or scalings of the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e2f18fb-a0e1-47fa-abf2-b8372d023f29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system = \"stereo\"\n",
+    "notes = [[\"C3\",\"D3\",\"E3\",\"G3\",\"B3\",\"C4\",\"D4\",\"E4\",\"G4\",\"B4\",\"C5\",\"D5\",\"E5\",\"G5\",\"B5\"]]\n",
+    "score =  Score(notes, 5, pitch_binning='uniform')\n",
+    "\n",
+    "maps = {'pitch':y,\n",
+    "        'time': x,\n",
+    "         'pan': x}\n",
+    "\n",
+    "# set up source\n",
+    "sources = Events(maps.keys())\n",
+    "sources.fromdict(maps)\n",
+    "sources.apply_mapping_functions()\n",
+    "\n",
+    "soni = Sonification(score, sources, copy.copy(synth), system)\n",
+    "soni.render()\n",
+    "dobj = soni.notebook_display(show_waveform=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74b4ae55-e98a-4298-802f-f21247b091ec",
+   "metadata": {},
+   "source": [
+    "While manually setting the old `strauss` defaults for `map_lims` (`[0,1]`) ***is*** affected by the offset and scale choices:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80c53d79-24f3-4896-b50e-f6d6258789da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lims = {'time': [0,1], 'pitch': [0,1], 'pan': [0,1]}\n",
+    "soni = Sonification(score, sources, copy.copy(synth), system)\n",
+    "sources.apply_mapping_functions(map_lims = lims)\n",
+    "soni.render()\n",
+    "dobj = soni.notebook_display(show_waveform=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e929b466-d176-4576-afbb-b472cd85bbd2",
+   "metadata": {},
+   "source": [
+    "for spatial angles, we instead assume an absolute unit system. Replacing pan with spatial angles, we remake the sonification. By default this is in 'cycles' (0-1 represents a whole circle), so we rescale azimuth values to this range:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b438c4e5-252e-42e1-af55-0fb4c019f2a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if 'pan' in maps:\n",
+    "    del maps['pan']\n",
+    "maps['azimuth'] = x/xscale\n",
+    "sources = Events(maps.keys())\n",
+    "sources.fromdict(maps)\n",
+    "soni = Sonification(score, sources, copy.copy(synth), system)\n",
+    "sources.apply_mapping_functions()\n",
+    "soni.render()\n",
+    "dobj = soni.notebook_display(show_waveform=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7132562b-9112-400b-a58e-6de0e64d938e",
+   "metadata": {},
+   "source": [
+    "There is a new `angle_unit` optional keyword to `apply_mapping_functions`. To guide the user, if no `map_lims` value or `angle_unit` is set it will warn as above. If we changed to radians, the same x values only traverse a sixth of a circle: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4725e0ad-e6ee-45f9-8549-885a4e0a6f9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if 'pan' in maps:\n",
+    "    del maps['pan']\n",
+    "maps['azimuth'] = x/xscale\n",
+    "sources = Events(maps.keys())\n",
+    "sources.fromdict(maps)\n",
+    "soni = Sonification(score, sources, copy.copy(synth), system)\n",
+    "sources.apply_mapping_functions(angle_unit='radians')\n",
+    "soni.render()\n",
+    "dobj = soni.notebook_display(show_waveform=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "473d860e-f44d-4083-981f-0f7afec929b7",
+   "metadata": {},
+   "source": [
+    "`degrees`, `radians` and `cycles` are supported as units. The user can also use `map_lims` to set a custom input range as before."
    ]
   }
  ],

--- a/tests/pre-merge/mapping_defaults.ipynb
+++ b/tests/pre-merge/mapping_defaults.ipynb
@@ -1,0 +1,218 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a4daee9-2e45-40e6-a85f-ae1b9f241faa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "from strauss.sonification import Sonification\n",
+    "from strauss.sources import Objects, Events\n",
+    "from strauss import channels\n",
+    "from strauss.score import Score\n",
+    "import numpy as np\n",
+    "from strauss.generator import Synthesizer\n",
+    "import IPython.display as ipd\n",
+    "import glob\n",
+    "import os\n",
+    "import copy\n",
+    "from pathlib import Path\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "151b6885-18a0-45b3-9df8-d06e4a9f28bb",
+   "metadata": {},
+   "source": [
+    "### <u> Mapping Defaults</u> "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4acd4d0b-3ea2-46e8-98fd-e0cf92f57b51",
+   "metadata": {},
+   "source": [
+    "Changed the default `map_lims` range from `[0,1]` to `['0%','100%']`: this means by default sound parameters adapt to the offgset and range of the data.\n",
+    "\n",
+    "The only exceptions to this are 3D spatial angles (e.g. `'polar'` and `'azimuth'`), which use an absolute unit system due to their cyclic nature. As 3D spatial mapping is relatively advanced, we also institute a new `'pan'` parameter, ranging from fully left to fully right, which can uses the same `['0%','100%']` defaults as other properties.\n",
+    "\n",
+    "To demonstrate, we set up a generator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60564738-70b7-4cf3-a703-66079b93da3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "synth = Synthesizer()\n",
+    "synth.load_preset('pitch_mapper')\n",
+    "# manually set note properties to get a suitable sound\n",
+    "synth.modify_preset({'note_length':0.03, # hold each note for 0.03 seconds or 30 ms - what if this was 1s?\n",
+    "                         'volume_envelope': {'use':'on', 'A':0.01,'R':0.07}}) # ✏️ Time to fade out once note is released, using 100 ms"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f05ad6e4-5a57-4774-935d-85eb8aff3295",
+   "metadata": {},
+   "source": [
+    "and some fake data, notably with offset and scaling relative to a `[0,1]` range"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5912f06-9a75-40a6-ab5c-70baf098cf59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "yoffset = -700\n",
+    "xscale = 100\n",
+    "\n",
+    "x = np.linspace(0,xscale,200)\n",
+    "y =np.log10( np.sin(60*x/scale) +1.01) + yoffset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ea44b2b-fb3c-40b4-b546-db2eff30e94d",
+   "metadata": {},
+   "source": [
+    "and then use an `Event` sonification, with a periodic `y` value mapped to `pitch` and additionally mapping `x` to `pan`. This shows a sonification that is unaffected by offsets or scalings of the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5aca165-7ed3-4746-9dfd-cbb48db13c0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system = \"stereo\"\n",
+    "notes = [[\"C3\",\"D3\",\"E3\",\"G3\",\"B3\",\"C4\",\"D4\",\"E4\",\"G4\",\"B4\",\"C5\",\"D5\",\"E5\",\"G5\",\"B5\"]]\n",
+    "score =  Score(notes, 5, pitch_binning='uniform')\n",
+    "\n",
+    "maps = {'pitch':y,\n",
+    "        'time': x,\n",
+    "         'pan': x}\n",
+    "\n",
+    "# set up source\n",
+    "sources = Events(maps.keys())\n",
+    "sources.fromdict(maps)\n",
+    "sources.apply_mapping_functions()\n",
+    "\n",
+    "soni = Sonification(score, sources, copy.copy(synth), system)\n",
+    "soni.render()\n",
+    "dobj = soni.notebook_display(show_waveform=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88ad1944-7d9e-4ae4-a3b8-a9a86563b6d7",
+   "metadata": {},
+   "source": [
+    "While manually setting the old `strauss` defaults for `map_lims` (`[0,1]`) ***is*** affected by the offset and scale choices:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "102edc99-862b-4297-86d2-daa3b3d7e187",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lims = {'time': [0,1], 'pitch': [0,1], 'pan': [0,1]}\n",
+    "soni = Sonification(score, sources, copy.copy(synth), system)\n",
+    "sources.apply_mapping_functions(map_lims = lims)\n",
+    "soni.render()\n",
+    "dobj = soni.notebook_display(show_waveform=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98d6e7eb-a4a3-4972-bbad-d0df0f6777f3",
+   "metadata": {},
+   "source": [
+    "for spatial angles, we instead assume an absolute unit system. Replacing pan with spatial angles, we remake the sonification. By default this is in 'cycles' (0-1 represents a whole circle), so we rescale azimuth values to this range:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "887b3b61-fc13-4214-9a09-df7f8bb58524",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if 'pan' in maps:\n",
+    "    del maps['pan']\n",
+    "maps['azimuth'] = x/xscale\n",
+    "sources = Events(maps.keys())\n",
+    "sources.fromdict(maps)\n",
+    "soni = Sonification(score, sources, copy.copy(synth), system)\n",
+    "sources.apply_mapping_functions()\n",
+    "soni.render()\n",
+    "dobj = soni.notebook_display(show_waveform=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13282eb3-4cc5-4518-ae69-0180c12e18b1",
+   "metadata": {},
+   "source": [
+    "There is a new `angle_unit` optional keyword to `apply_mapping_functions`. To guide the user, if no `map_lims` value or `angle_unit` is set it will warn as above. If we changed to radians, the same x values only traverse a sixth of a circle: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "573437ef-ed55-411d-8f9c-759505561e68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if 'pan' in maps:\n",
+    "    del maps['pan']\n",
+    "maps['azimuth'] = x/xscale\n",
+    "sources = Events(maps.keys())\n",
+    "sources.fromdict(maps)\n",
+    "soni = Sonification(score, sources, copy.copy(synth), system)\n",
+    "sources.apply_mapping_functions(angle_unit='radians')\n",
+    "soni.render()\n",
+    "dobj = soni.notebook_display(show_waveform=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bde4e3e-fd2f-4db4-9550-2fb975e3659f",
+   "metadata": {},
+   "source": [
+    "`degrees`, `radians` and `cycles` are supported as units. The user can also use `map_lims` to set a custom input range as before."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### **⚠️ Changes to default behaviour ⚠️**

addresses https://github.com/james-trayford/strauss/issues/48

### A number of grouped changes from the `v2` requested features:
- New `map_lims` defaults of `('0%', '100%')` as a more intuitive default, instead of the existing default `[0,1]` which requires users to rescale their values between 0 and 1. Previously this was motivated by the need to have an absolute scale for spatial angles. With 'pan' (below) as a new, entry point to spatialisation that supports a monotonic relative scaling, we move spatial angles to a special case
- New `pan` parameter going from hard left to hard right (a remapping of the `azimuth` parameter as a half circle from `90` to `270` degrees)
- New default `polar` value of `90` degrees, placing sources on the listener plane when unspecified
- Ability to specify `angle_unit` (`'degrees'`, `'radians'`, `'cycles'`) as a `Sources` argument, with warnings if attempt to overwrite with a `map_lims` entry.
- New `Sources` `validate_mapping` method to catch invalid parameter pairs in the `apply_mapping_functions` step, with errors for invalid parameter combos (such as `'pan'` and spatial angles) and warnings about things like 

### To Do
- [x] Make sure angle unit system obeyed
- [x] Make sure angle special units obeyed
- [ ] Update docs (docstrings, param docs)
- [x] Update `tests/`