### PR TITLE
Fix SyntaxErrors by turning regex strings into raw strings

### DIFF
--- a/src/strauss/generator.py
+++ b/src/strauss/generator.py
@@ -43,7 +43,7 @@ from pathlib import Path
 import os
 
 # ignore wavfile read warning that complains due to WAV file metadata
-warnings.filterwarnings("ignore", message="Chunk \(non-data\) not understood, skipping it\.")
+warnings.filterwarnings("ignore", message=r"Chunk \(non-data\) not understood, skipping it\.")
 
 # TO DO:
 # - Ultimately have Synth and Sampler classes that own their own stream (stream.py) object

--- a/src/strauss/notes.py
+++ b/src/strauss/notes.py
@@ -42,7 +42,7 @@ def parse_note(notename):
     Returns:
       out (numerical): Frequency of note in Hertz
     """
-    nsplit = re.findall("(\D+|\d+)", notename)
+    nsplit = re.findall(r"(\D+|\d+)", notename)
     semi = semitone_dict[nsplit[0]]/12.
     octv  = int(nsplit[1])
     return tuneC0*pow(2.,semi+octv)

--- a/src/strauss/score.py
+++ b/src/strauss/score.py
@@ -63,7 +63,7 @@ class Score:
         """
         # check types to handle score length correctly
         if isinstance(length, str):
-            regex = "([0-9]*)m\s*([0-9]*.[0-9]*)s"
+            regex = r"([0-9]*)m\s*([0-9]*.[0-9]*)s"
             reobj = re.match(regex, length, re.M | re.I)
             self.length = float(reobj.group(1))*60. + float(reobj.group(2))            
         else:


### PR DESCRIPTION
For whatever reason when I went to run strauss in a clean environment I kept getting a series of `SyntaxError: invalid escape sequence '\<something>'` when simply trying to import from strauss. Looking at it all of the issues were in regex strings which can be turned into raw strings. This PR fixes the ones I encountered.