### PR TITLE
Explicit NaN (and general non-finite) Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   thinned along with the data.
 - `merge_mode`, a `Style` field also settable per `sonify` call, choosing how events
   merged by `max_notes_per_sec` take their values (see **Changed**).
+- Table columns now have a nicely formatted name and can also carry a (square-bracketed)
+  unit, which uses pandas 'multi-index' functionality to display nicely - e.g.
+  `Cutoff Frequency`, `[Hz]`. These survive export to CSV, read back with `header=[0,1]`.
+- Fixed table adds a `unit` column.
+- Units are drawn from the generator `ranges` files if not specified elsewhere, then
+  nothing for `pitch` (becomes `Note`). Haven't figured out spectraliser `spectrum` yet
+  (unitless for now).
+- Converters give the most intuitive representation of each parameter - `pan` as % right,
+  `volume` as dB with `-inf` below -100 dB, `cutoff` in Hz, `time` in seconds. The cutoff
+  conversion shares its frequency limits with `Stream.filt_sweep`, so the two can't drift.
+- Custom rounding per parameter for table display, resolving each column's range into
+  about a thousand steps - a tenth of a degree for angles, a thousandth of a cycle for the
+  same angles in cycles. Times are never coarser than 10 ms, for syncing to video.
 
 ### Changed
 
@@ -36,6 +49,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adaptive pitch binning no longer spreads a constant pitch across the chord in input
   order, instead binning it as `'uniform'` does. Affects `Events` sonifications with no
   `pitch` mapping.
+- Generator `ranges` file fixes - `pan` had no entry at all and `volume_lfo/amount` no
+  unit, the envelope segments declared limits of 20 s where mapping uses 10, `1e-2`
+  parsed as a string rather than a float (YAML needs `1.0e-2`), and the `theta`/`phi`
+  units were the wrong way round.
+- dB conversion now lives in `utilities`, as `amplitude_to_db` and `db_to_amplitude`, and
+  is shared with `AudioFigure._parse_level` - so mixing levels and reported volumes use
+  one definition of the convention.
 
 ## v1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom rounding per parameter for table display, resolving each column's range into
   about a thousand steps - a tenth of a degree for angles, a thousandth of a cycle for the
   same angles in cycles. Times are never coarser than 10 ms, for syncing to video.
+- `handle_nans`, a `Style` field also settable per `sonify` call and as a keyword on
+  `Sources` and `Sonification`, deciding what becomes of missing (`NaN` or infinite)
+  input data. Both modes record what was missing in `Sources.nan_mask` and linearly
+  interpolate it in time, so it can no longer propagate through the mapping.
+  `'interpolate'` then sounds the interpolated data as it is; `'silent'` (the default)
+  additionally silences the audio it would have made, so a gap in the data is heard as
+  a gap in the sound. `Events` missing a value are skipped outright, being discrete in
+  time, with their names thinned alongside them; `Objects` are muted over the interval
+  they are missing, ramping down over `declick_time` from the last point with data and
+  back up to the next one, so the gap doesn't click. A missing `spectrum` bin is the
+  exception, meaning no power at that frequency rather than a gap in the data, so it is
+  zeroed rather than interpolated and doesn't mute the time it sits at. Tables gain a
+  `Missing` column flagging what sounds at an interpolated value.
 
 ### Changed
 
@@ -56,6 +69,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dB conversion now lives in `utilities`, as `amplitude_to_db` and `db_to_amplitude`, and
   is shared with `AudioFigure._parse_level` - so mixing levels and reported volumes use
   one definition of the convention.
+- Mapping limits ignore non-finite values, so one `NaN` in a column no longer returns
+  `NaN` from the percentiles and sets the limits every source is descaled by. Data with
+  no non-finite values renders bit-identically to before.
+- Events merged by `max_notes_per_sec` no longer let one missing value take its whole
+  cluster with it - a cluster averages to `NaN` only where none of its members has a
+  value. Events with a non-finite `time` are dropped before merging, having no point in
+  the sonification to be placed at.
+- `Events.fromdict` and `Objects.fromdict` now raise on a mapped property missing from
+  the data, rather than constructing an unraised `Exception` and failing later, and take
+  `n_sources` from the first mapped quantity rather than from whichever the loop left
+  behind.
 
 ## v1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.5
+
+### Added
+
+- Timing tables, describing what sounded and when. `Events` sonifications have a single
+  table of events, `Objects` sonifications one per source, via `Sonification.event_table()`
+  and `.object_table(source)`, or `AudioFigure.get_table()` which picks the right one.
+  `.fixed_table()` lists the parameters the user didn't map and the value each took.
+  `AudioFigure.list_tables()` shows what's tabulated. Tables are built from the mapping,
+  prior to render, and report what's heard: notes rather than pitch fractions, seconds
+  rather than fractions of the duration and degrees rather than cycles.
+- Sources can be named, via `sonify(source_names=[...])` or `Sources.names`, and their
+  tables looked up by name. For `Events` give one name per input event, and they are
+  thinned along with the data.
+- `merge_mode`, a `Style` field also settable per `sonify` call, choosing how events
+  merged by `max_notes_per_sec` take their values (see **Changed**).
+
+### Changed
+
+- Events merged by `max_notes_per_sec` now take the values of the event closest to the
+  middle of those merged, rather than the mean of them, so each remains a real data point.
+  Merged events still sound at the mean time, so the maximum rate still holds. Use
+  `merge_mode: 'average'` for the previous behaviour.
+- Azimuthal angles are merged as directions rather than numbers, so that a cluster of
+  events straddling the wrap point no longer merges to the opposite direction.
+- `angle_unit` defaults to `'cycles'` rather than `'degrees'`, matching the mapped
+  parameters themselves. Spatial angles are still reported in degrees in tables unless
+  an `angle_unit` is asked for.
+- Adaptive pitch binning no longer spreads a constant pitch across the chord in input
+  order, instead binning it as `'uniform'` does. Affects `Events` sonifications with no
+  `pitch` mapping.
+
 ## v1.3
 
 ### Added

--- a/src/strauss/__init__.py
+++ b/src/strauss/__init__.py
@@ -29,6 +29,32 @@ def sonify(*args, channels='stereo', **kwargs):
     fig = _get_current_figure(system=channels)
     return fig.sonify(*args, **kwargs)
 
+def get_table(*args, **kwargs):
+    """Get the timing table of a sonification in the current figure.
+
+    Takes the same arguments as, and is documented by,
+    :meth:`~strauss.audio_figure.AudioFigure.get_table`.
+    """
+    fig = _get_current_figure()
+    return fig.get_table(*args, **kwargs)
+
+def get_fixed_table(*args, **kwargs):
+    """Get the unmapped parameters of a sonification in the current figure.
+
+    Takes the same arguments as, and is documented by,
+    :meth:`~strauss.audio_figure.AudioFigure.get_fixed_table`.
+    """
+    fig = _get_current_figure()
+    return fig.get_fixed_table(*args, **kwargs)
+
+def list_tables():
+    """Print the tables available from the current figure.
+
+    Documented by :meth:`~strauss.audio_figure.AudioFigure.list_tables`.
+    """
+    fig = _get_current_figure()
+    return fig.list_tables()
+
 def close():
     _current_figure.set(None)
     

--- a/src/strauss/__init__.py
+++ b/src/strauss/__init__.py
@@ -49,21 +49,13 @@ def save(fname):
     fig = _get_current_figure()
     fig.save(fname)
     
-def get_event_table(name=None, include_input=False):
-    fig = _get_current_figure()
-    fig.get_event_table(name, include_input)
-    
-def get_object_table(name=None, source=None, include_input=False):
-    fig = _get_current_figure()
-    fig.get_object_table(source, include_input)
-    
 def get_fixed_table(name=None, source=None):
     fig = _get_current_figure()
-    fig.get_fixed_table(name, source)
+    return fig.get_fixed_table(name, source)
     
 def get_table(name=None, source=None, include_input=False):
     fig = _get_current_figure()
-    fig.get_table(name, source, include_input)
+    return fig.get_table(name, source, include_input)
     
 def list_tables():
     fig = _get_current_figure()

--- a/src/strauss/__init__.py
+++ b/src/strauss/__init__.py
@@ -29,32 +29,6 @@ def sonify(*args, channels='stereo', **kwargs):
     fig = _get_current_figure(system=channels)
     return fig.sonify(*args, **kwargs)
 
-def get_table(*args, **kwargs):
-    """Get the timing table of a sonification in the current figure.
-
-    Takes the same arguments as, and is documented by,
-    :meth:`~strauss.audio_figure.AudioFigure.get_table`.
-    """
-    fig = _get_current_figure()
-    return fig.get_table(*args, **kwargs)
-
-def get_fixed_table(*args, **kwargs):
-    """Get the unmapped parameters of a sonification in the current figure.
-
-    Takes the same arguments as, and is documented by,
-    :meth:`~strauss.audio_figure.AudioFigure.get_fixed_table`.
-    """
-    fig = _get_current_figure()
-    return fig.get_fixed_table(*args, **kwargs)
-
-def list_tables():
-    """Print the tables available from the current figure.
-
-    Documented by :meth:`~strauss.audio_figure.AudioFigure.list_tables`.
-    """
-    fig = _get_current_figure()
-    return fig.list_tables()
-
 def close():
     _current_figure.set(None)
     
@@ -74,3 +48,23 @@ def set_level(name, level):
 def save(fname):
     fig = _get_current_figure()
     fig.save(fname)
+    
+def get_event_table(name=None, include_input=False):
+    fig = _get_current_figure()
+    fig.get_event_table(name, include_input)
+    
+def get_object_table(name=None, source=None, include_input=False):
+    fig = _get_current_figure()
+    fig.get_object_table(source, include_input)
+    
+def get_fixed_table(name=None, source=None):
+    fig = _get_current_figure()
+    fig.get_fixed_table(name, source)
+    
+def get_table(name=None, source=None, include_input=False):
+    fig = _get_current_figure()
+    fig.get_table(name, source, include_input)
+    
+def list_tables():
+    fig = _get_current_figure()
+    fig.list_tables()

--- a/src/strauss/audio_figure.py
+++ b/src/strauss/audio_figure.py
@@ -461,7 +461,30 @@ class AudioFigure:
         """
         return self._get_sonification(name).event_table(include_input=include_input)
 
-    def get_fixed_table(self, name=None):
+    def get_object_table(self, name=None, source=None, include_input=False):
+        """Get the table of one object's evolution in a sonification.
+
+        Wrapper for
+        :meth:`~strauss.sonification.Sonification.object_table`, giving
+        a row per point in the object's evolution.
+
+        Args:
+          name (`optional`, :obj:`str`): name of the sonification. Can
+            be omitted where the figure holds only one.
+          source (`optional`, :obj:`str` or :obj:`int`): name or index
+            of the source. Can be omitted where the sonification has
+            only one.
+          include_input (`optional`, :obj:`bool`): if True, also give
+            the input data value of each parameter, before mapping.
+
+        Returns:
+          table (:obj:`pandas.DataFrame`): one row per point in the
+          object's evolution
+        """
+        soni = self._get_sonification(name)
+        return soni.object_table(source, include_input=include_input)
+
+    def get_fixed_table(self, name=None, source=None):
         """Get the table of unmapped parameters for a sonification.
 
         Wrapper for
@@ -472,11 +495,68 @@ class AudioFigure:
         Args:
           name (`optional`, :obj:`str`): name of the sonification. Can
             be omitted where the figure holds only one.
+          source (`optional`, :obj:`str` or :obj:`int`): name or index
+            of a source to report values for. If omitted, values are
+            reported for the sonification as a whole.
 
         Returns:
           table (:obj:`pandas.DataFrame`): one row per unmapped parameter
         """
-        return self._get_sonification(name).fixed_table()
+        return self._get_sonification(name).fixed_table(source)
+
+    def get_table(self, name=None, source=None, include_input=False):
+        """Get the timing table for a sonification.
+
+        Returns the table appropriate to the sonification's source type
+        - :meth:`get_event_table` for `Events`, where the sonification
+        has a single table of events, and :meth:`get_object_table` for
+        `Objects`, where each source has a table of its own evolution.
+
+        Args:
+          name (`optional`, :obj:`str`): name of the sonification. Can
+            be omitted where the figure holds only one.
+          source (`optional`, :obj:`str` or :obj:`int`): name or index
+            of the source, for `Objects` sonifications. Can be omitted
+            where the sonification has only one.
+          include_input (`optional`, :obj:`bool`): if True, also give
+            the input data value of each parameter, before mapping.
+
+        Returns:
+          table (:obj:`pandas.DataFrame`): the sonification's table of
+          events, or the named source's table of evolution
+
+        Raises:
+          TypeError: if a `source` is given for an `Events`
+            sonification, where events are not divided by source.
+        """
+        soni = self._get_sonification(name)
+
+        if isinstance(soni.sources, sources.Events):
+            if source is not None:
+                raise TypeError("Events sonifications have a single table of "
+                                f"all events, so cannot take source '{source}'.")
+            return soni.event_table(include_input=include_input)
+
+        return soni.object_table(source, include_input=include_input)
+
+    def list_tables(self):
+        """Print the tables available from this figure.
+
+        Lists each sonification with the tables it offers - a single
+        table of events for `Events` sonifications, or one per named
+        source, with the note it plays, for `Objects`.
+        """
+        for i, (name, soni) in enumerate(self.sonifications.items()):
+            stype = type(soni.sources).__name__
+            print(f"\t{i+1}.\t {name} ({stype})")
+
+            if isinstance(soni.sources, sources.Events):
+                print(f"\t\t - {soni.sources.n_sources} events")
+                continue
+
+            notes, _ = soni._assign_notes()
+            for sname, note in zip(soni.sources.names, notes):
+                print(f"\t\t - {sname} ({note})")
 
     def rename(self, old, new):
         dicts = [self.sonifications, self.levels, self.styles, self.figure_hashes]

--- a/src/strauss/audio_figure.py
+++ b/src/strauss/audio_figure.py
@@ -260,16 +260,41 @@ class AudioFigure:
                 
         nmap = min(len(args), len(style.map))
         
+        source_names = sonpars['source_names']
+
         if (style.sources.lower() == 'events') and style.max_notes_per_sec:
+            tdx = None
             for i in range(nmap):
                 if style.map[i].output == 'time':
+                    tdx = i
                     tlims = style.map[i].input_range
                     tlims = set_limits(tlims, args[i], warn=False)
                     time = rescale_values(args[i], tlims, (0,1))
                     break
-            
+
+            # names are given per input event, so must be thinned alongside
+            # the data they name
+            if (source_names is not None) and (len(source_names) != len(args[0])):
+                raise ValueError(f"Got {len(source_names)} source names for "
+                                 f"{len(args[0])} input events.")
+
+            # azimuthal angles wrap around the circle, so must be merged as
+            # directions. Any angle given an input_range is mapped linearly
+            # rather than wrapped, so is merged that way too
+            amax = sources.angle_unit_maxs[sonpars['angle_unit']]
+            cyclic = {i: amax for i in range(nmap)
+                      if (style.map[i].output in sources.azimuthal_angles)
+                      and ('input_range' not in style.map[i].model_fields_set)}
+
             # lets now thin the data according to max events per second if using events
-            args = merge_events(sonpars['duration'], style.max_notes_per_sec, time, args)
+            args, repdx = merge_events(sonpars['duration'], style.max_notes_per_sec,
+                                       time, args, mode=style.merge_mode,
+                                       time_index=tdx, cyclic=cyclic,
+                                       return_index=True)
+
+            if source_names is not None:
+                # each merged event takes the name of the event representing it
+                source_names = [source_names[i] for i in repdx]
         
         to_map = []
         in_lims = {}
@@ -360,8 +385,8 @@ class AudioFigure:
         _sources.fromdict(map_data)
 
         # name the sources, now that we know how many there are
-        if sonpars['source_names'] is not None:
-            _sources.names = sonpars['source_names']
+        if source_names is not None:
+            _sources.names = source_names
         _sources.apply_mapping_functions(map_funcs=mapping_functions, map_lims=in_lims,
                                          param_lims=out_lims, angle_unit=sonpars['angle_unit'])
 

--- a/src/strauss/audio_figure.py
+++ b/src/strauss/audio_figure.py
@@ -60,6 +60,8 @@ _kw_defaults = {
     'is_mapped': ['pitch', 'time_evo'],
     # units assumed for spatial angles (polar, azimuth, theta, phi)
     'angle_unit': 'degrees',
+    # names to identify each source by, when looking up its table
+    'source_names': None,
     # Style File
     'style' : None,
     'caption': None,
@@ -356,6 +358,10 @@ class AudioFigure:
         _sources = getattr(sources, style.sources.capitalize())(to_map)
         _sources.origin = origin
         _sources.fromdict(map_data)
+
+        # name the sources, now that we know how many there are
+        if sonpars['source_names'] is not None:
+            _sources.names = sonpars['source_names']
         _sources.apply_mapping_functions(map_funcs=mapping_functions, map_lims=in_lims,
                                          param_lims=out_lims, angle_unit=sonpars['angle_unit'])
 

--- a/src/strauss/audio_figure.py
+++ b/src/strauss/audio_figure.py
@@ -177,6 +177,12 @@ class AudioFigure:
         if not sonpars['style']:
             sonpars['style'] = 'default'
         style = styles.Style(**load_style(sonpars['style']))
+
+        # an entry is a data mapping or a fixed value by what it holds, not by
+        # where it sits in the map. Data mappings take the input data in the
+        # order they are given
+        data_maps = [m for m in style.map if m.fixed is None]
+        fixed_maps = [m for m in style.map if m.fixed is not None]
         
         # Check if data is in CSV or Pandas DataFrame format
         if len(args) == 1:
@@ -191,7 +197,7 @@ class AudioFigure:
             # If using CSV or DF, check for specified 'input' columns in style and resolve these
             if df is not None:
                 resolved = []
-                for i, mapping in enumerate(style.map):
+                for i, mapping in enumerate(data_maps):
                     col = getattr(mapping, 'input', None)
                     if col is None:
                         # If no input, default to auto-mapping based on position in style file
@@ -262,8 +268,15 @@ class AudioFigure:
             args = [np.arange(len(args[0])), args[0]]
             tlims = (0,args[0][-1])
                 
-        nmap = min(len(args), len(style.map))
-        
+        if len(data_maps) > len(args):
+            # a style may map more than the data given, drop these quietly for now.
+            data_maps = data_maps[:len(args)]
+        elif len(args) > len(data_maps):
+            # data given that no mapping asks for is more likely a mistake
+            warnings.warn(f"{len(args)} data arrays were given but the style "
+                          f"maps only {len(data_maps)} parameters, so the last "
+                          f"{len(args) - len(data_maps)} will not be used.")
+
         source_names = sonpars['source_names']
 
         # a merge_mode keyword overrides the style
@@ -274,10 +287,10 @@ class AudioFigure:
 
         if (style.sources.lower() == 'events') and style.max_notes_per_sec:
             tdx = None
-            for i in range(nmap):
-                if style.map[i].output == 'time':
+            for i, mapping in enumerate(data_maps):
+                if mapping.output == 'time':
                     tdx = i
-                    tlims = style.map[i].input_range
+                    tlims = mapping.input_range
                     tlims = set_limits(tlims, args[i], warn=False)
                     time = rescale_values(args[i], tlims, (0,1))
                     break
@@ -292,9 +305,9 @@ class AudioFigure:
             # directions. Any angle given an input_range is mapped linearly
             # rather than wrapped, so is merged that way too
             amax = sources.angle_unit_maxs[sonpars['angle_unit']]
-            cyclic = {i: amax for i in range(nmap)
-                      if (style.map[i].output in sources.azimuthal_angles)
-                      and ('input_range' not in style.map[i].model_fields_set)}
+            cyclic = {i: amax for i, m in enumerate(data_maps)
+                      if (m.output in sources.azimuthal_angles)
+                      and ('input_range' not in m.model_fields_set)}
 
             # lets now thin the data according to max events per second if using events
             args, clusters = merge_events(sonpars['duration'], style.max_notes_per_sec,
@@ -325,9 +338,8 @@ class AudioFigure:
         origin = {}
         
         # Iterate through the mappings and add lims and funcs to their own dicts
-        for i in range(nmap):
-            mapping = style.map[i]
-            
+        for mapping in data_maps:
+
             if mapping.output == 'time' and style.sources == 'objects':
                 # Automatically swap time for time_evo if using Objects
                 mapping.output = 'time_evo'
@@ -348,7 +360,7 @@ class AudioFigure:
             if mapping.function:
                 funcs = [mapping.function] if isinstance(mapping.function, str) else mapping.function
                 mapping_functions[to_map[-1]] = [styles.MAPPING_FUNCTIONS[f] for f in funcs]
-        map_data = dict(zip(to_map, args[:nmap]))
+        map_data = dict(zip(to_map, args[:len(data_maps)]))
         
         if 'pitch' not in to_map:
             to_map.append('pitch')
@@ -365,26 +377,22 @@ class AudioFigure:
                 map_data["pitch"] = np.zeros(len(map_data[to_map[0]]))
         
         # we now iterate through style fixed values
-        for i in range(nmap, len(style.map)):
-            mapping = style.map[i]
-            if mapping.fixed is not None:
-                if mapping.output in to_map:
-                    warnings.warn(f"'{mapping.output}' is mapped earlier in the "
-                                  f"style, but is being fixed at {mapping.fixed}.")
-                else:
-                    to_map.append(mapping.output)
-                origin[mapping.output] = 'fixed'
+        for mapping in fixed_maps:
+            if mapping.output in to_map:
+                warnings.warn(f"'{mapping.output}' is mapped by the style, but "
+                              f"is also being fixed at {mapping.fixed}.")
+            else:
+                to_map.append(mapping.output)
+            origin[mapping.output] = 'fixed'
 
-                if mapping.output not in sources.spatial_angles:
-                    lims = sources.param_lim_dict[mapping.output]
-                    in_lims[mapping.output] = lims
-                    out_lims[mapping.output] = lims
-                # spatial angles are left to apply_mapping_functions, which
-                # scales them by angle_unit and wraps them around the circle
+            if mapping.output not in sources.spatial_angles:
+                lims = sources.param_lim_dict[mapping.output]
+                in_lims[mapping.output] = lims
+                out_lims[mapping.output] = lims
+            # spatial angles are left to apply_mapping_functions, which
+            # scales them by angle_unit and wraps them around the circle
 
-                fix_array =  len(map_data[to_map[0]])*[mapping.fixed]
-
-                map_data[mapping.output] = fix_array
+            map_data[mapping.output] = len(map_data[to_map[0]])*[mapping.fixed]
 
         # and finally overwrite with any kwarg fixed values:
         for k in sonpars.keys():

--- a/src/strauss/audio_figure.py
+++ b/src/strauss/audio_figure.py
@@ -273,6 +273,10 @@ class AudioFigure:
         in_lims = {}
         out_lims = {}
         mapping_functions = {}
+
+        # track where each mapping came from, so that tables and summaries
+        # can tell user-specified mappings from those we add here
+        origin = {}
         
         # Iterate through the mappings and add lims and funcs to their own dicts
         for i in range(nmap):
@@ -288,8 +292,9 @@ class AudioFigure:
                 style.generator.mods["filter"] = "on" 
                 
             to_map.append(mapping.output)
+            origin[to_map[-1]] = 'mapped'
 
-            # only limits explicitly  asked for given angle_unit handling 
+            # only limits explicitly  asked for given angle_unit handling
             if 'input_range' in mapping.model_fields_set:
                 in_lims[to_map[-1]] = mapping.input_range
             if mapping.output_range:
@@ -301,7 +306,8 @@ class AudioFigure:
         
         if 'pitch' not in to_map:
             to_map.append('pitch')
-            
+            origin['pitch'] = 'auto'
+
             if style.sources == 'objects':
                 nnote = len(style.notes)
                 for k in map_data.keys():
@@ -317,6 +323,7 @@ class AudioFigure:
             mapping = style.map[i]
             if mapping.fixed is not None:
                 to_map.append(mapping.output)
+                origin[mapping.output] = 'fixed'
 
                 if mapping.output not in sources.spatial_angles:
                     lims = sources.param_lim_dict[mapping.output]
@@ -343,9 +350,11 @@ class AudioFigure:
                     in_lims[prop] = sources.param_lim_dict[prop]
                     out_lims[prop] = sources.param_lim_dict[prop]
                 to_map.append(prop)
+                origin[prop] = 'fixed'
 
        
         _sources = getattr(sources, style.sources.capitalize())(to_map)
+        _sources.origin = origin
         _sources.fromdict(map_data)
         _sources.apply_mapping_functions(map_funcs=mapping_functions, map_lims=in_lims,
                                          param_lims=out_lims, angle_unit=sonpars['angle_unit'])

--- a/src/strauss/audio_figure.py
+++ b/src/strauss/audio_figure.py
@@ -63,6 +63,9 @@ _kw_defaults = {
     'angle_unit': 'cycles',
     # names to identify each source by, when looking up its table
     'source_names': None,
+    # how events merged by max_notes_per_sec take their values, overriding
+    # the style's own merge_mode where given
+    'merge_mode': None,
     # Style File
     'style' : None,
     'caption': None,
@@ -263,6 +266,12 @@ class AudioFigure:
         
         source_names = sonpars['source_names']
 
+        # a merge_mode keyword overrides the style
+        merge_mode = sonpars['merge_mode'] or style.merge_mode
+        if merge_mode not in ('average', 'central'):
+            raise ValueError(f"merge_mode '{merge_mode}' is not recognised, "
+                             "choose from 'average' or 'central'.")
+
         if (style.sources.lower() == 'events') and style.max_notes_per_sec:
             tdx = None
             for i in range(nmap):
@@ -289,12 +298,12 @@ class AudioFigure:
 
             # lets now thin the data according to max events per second if using events
             args, clusters = merge_events(sonpars['duration'], style.max_notes_per_sec,
-                                          time, args, mode=style.merge_mode,
+                                          time, args, mode=merge_mode,
                                           time_index=tdx, cyclic=cyclic,
                                           return_index=True)
 
             if source_names is not None:
-                if style.merge_mode == 'central':
+                if merge_mode == 'central':
                     # the merged event is the event representing it, so is named
                     # by it
                     source_names = [source_names[i] for i in clusters['central']]
@@ -392,6 +401,11 @@ class AudioFigure:
        
         _sources = getattr(sources, style.sources.capitalize())(to_map)
         _sources.origin = origin
+
+        # report angles in whatever units they were given in, or in degrees
+        # where the user expressed no preference
+        if not is_default['angle_unit']:
+            _sources.table_angle_unit = sonpars['angle_unit']
         _sources.fromdict(map_data)
 
         # name the sources, now that we know how many there are

--- a/src/strauss/audio_figure.py
+++ b/src/strauss/audio_figure.py
@@ -58,6 +58,8 @@ INTMAX32 = (pow(2, 31)-1)
 _kw_defaults = {
     'duration': 10,
     'is_mapped': ['pitch', 'time_evo'],
+    # units assumed for spatial angles (polar, azimuth, theta, phi)
+    'angle_unit': 'degrees',
     # Style File
     'style' : None,
     'caption': None,
@@ -286,7 +288,9 @@ class AudioFigure:
                 style.generator.mods["filter"] = "on" 
                 
             to_map.append(mapping.output)
-            if mapping.input_range:
+
+            # only limits explicitly  asked for given angle_unit handling 
+            if 'input_range' in mapping.model_fields_set:
                 in_lims[to_map[-1]] = mapping.input_range
             if mapping.output_range:
                 out_lims[to_map[-1]] = mapping.output_range
@@ -311,16 +315,20 @@ class AudioFigure:
         # we now iterate through style fixed values
         for i in range(nmap, len(style.map)):
             mapping = style.map[i]
-            if mapping.fixed:
-                if mapping.input_range:
-                    in_lims[to_map[-1]] = mapping.input_range
-                if mapping.output_range:
-                    out_lims[to_map[-1]] = mapping.output_range
+            if mapping.fixed is not None:
+                to_map.append(mapping.output)
+
+                if mapping.output not in sources.spatial_angles:
+                    lims = sources.param_lim_dict[mapping.output]
+                    in_lims[mapping.output] = lims
+                    out_lims[mapping.output] = lims
+                # spatial angles are left to apply_mapping_functions, which
+                # scales them by angle_unit and wraps them around the circle
 
                 fix_array =  len(map_data[to_map[0]])*[mapping.fixed]
-                to_map.append(mapping.output)
+
                 map_data[mapping.output] = fix_array
-                    
+
         # and finally overwrite with any kwarg fixed values:
         for k in sonpars.keys():
             ksplit = k.split('fix_')
@@ -329,19 +337,18 @@ class AudioFigure:
                 if prop in to_map:
                     print(f'Overwriting {prop} with fixed value...')
                 map_data[prop] = [sonpars[k]]*len(map_data[to_map[0]])
-                if prop in ['azimuth', 'polar']:
-                    if prop == 'polar':
-                        in_lims[prop] = (0,180)
-                    if prop == 'azimuth':
-                        in_lims[prop] = (0,360)
-                else:
-                    in_lims[prop] = (0,1)
+                # as above: angles are scaled and wrapped later
+                
+                if prop not in sources.spatial_angles:
+                    in_lims[prop] = sources.param_lim_dict[prop]
+                    out_lims[prop] = sources.param_lim_dict[prop]
                 to_map.append(prop)
 
        
         _sources = getattr(sources, style.sources.capitalize())(to_map)
         _sources.fromdict(map_data)
-        _sources.apply_mapping_functions(map_funcs=mapping_functions, map_lims=in_lims, param_lims=out_lims)
+        _sources.apply_mapping_functions(map_funcs=mapping_functions, map_lims=in_lims,
+                                         param_lims=out_lims, angle_unit=sonpars['angle_unit'])
 
         # Set up Generator
         gentype = style.generator.type

--- a/src/strauss/audio_figure.py
+++ b/src/strauss/audio_figure.py
@@ -22,7 +22,8 @@ from .score import Score
 from .sources import Events, Objects, set_limits
 from .generator import Synthesizer, Sampler, Spectralizer
 from .sonification import Sonification
-from .utilities import nested_dict_reassign, merge_events, rescale_values
+from .utilities import (nested_dict_reassign, merge_events, rescale_values,
+                        db_to_amplitude)
 
 import numpy as np
 from . import channels
@@ -733,8 +734,7 @@ class AudioFigure:
             elif level_clean.endswith('db'):
                 try:
                     db_val = float(level_clean.replace('db', '').strip())
-                    # Convert dB to amplitude: 10^(dB/20)
-                    return 10 ** (db_val / 20.0)
+                    return float(db_to_amplitude(db_val))
                 except ValueError:
                     raise ValueError(f"Invalid dB format: {level}")
             else:

--- a/src/strauss/audio_figure.py
+++ b/src/strauss/audio_figure.py
@@ -58,8 +58,9 @@ INTMAX32 = (pow(2, 31)-1)
 _kw_defaults = {
     'duration': 10,
     'is_mapped': ['pitch', 'time_evo'],
-    # units assumed for spatial angles (polar, azimuth, theta, phi)
-    'angle_unit': 'degrees',
+    # units assumed for spatial angles (polar, azimuth, theta, phi), where
+    # a cycle is a full turn, as the mapped parameters themselves are
+    'angle_unit': 'cycles',
     # names to identify each source by, when looking up its table
     'source_names': None,
     # Style File
@@ -287,14 +288,23 @@ class AudioFigure:
                       and ('input_range' not in style.map[i].model_fields_set)}
 
             # lets now thin the data according to max events per second if using events
-            args, repdx = merge_events(sonpars['duration'], style.max_notes_per_sec,
-                                       time, args, mode=style.merge_mode,
-                                       time_index=tdx, cyclic=cyclic,
-                                       return_index=True)
+            args, clusters = merge_events(sonpars['duration'], style.max_notes_per_sec,
+                                          time, args, mode=style.merge_mode,
+                                          time_index=tdx, cyclic=cyclic,
+                                          return_index=True)
 
             if source_names is not None:
-                # each merged event takes the name of the event representing it
-                source_names = [source_names[i] for i in repdx]
+                if style.merge_mode == 'central':
+                    # the merged event is the event representing it, so is named
+                    # by it
+                    source_names = [source_names[i] for i in clusters['central']]
+                else:
+                    # the merged event is an average of several, so name it for
+                    # the span it covers, from the earliest event to the latest
+                    source_names = [source_names[a] if a == b else
+                                    f'{source_names[a]}->{source_names[b]}'
+                                    for a, b in zip(clusters['first'],
+                                                    clusters['last'])]
         
         to_map = []
         in_lims = {}

--- a/src/strauss/audio_figure.py
+++ b/src/strauss/audio_figure.py
@@ -405,6 +405,73 @@ class AudioFigure:
         for i, k in enumerate(self.sonifications.keys()):
             print(f"\t{i+1}.\t {k}")
 
+    def _get_sonification(self, name=None):
+        """Look up one of the figure's sonifications by name.
+
+        Args:
+          name (`optional`, :obj:`str`): name of the sonification. Can
+            be omitted where the figure holds only one.
+
+        Returns:
+          soni (:class:`~strauss.sonification.Sonification`): the named
+          sonification
+
+        Raises:
+          KeyError: if no such sonification exists, or if no name is
+            given for a figure holding more than one.
+        """
+        if not self.sonifications:
+            raise KeyError("AudioFigure has no sonifications yet.")
+
+        if name is None:
+            if len(self.sonifications) > 1:
+                raise KeyError("AudioFigure has more than one sonification, so "
+                               "a 'name' is needed. Choose from: "
+                               f"{list(self.sonifications)}")
+            return next(iter(self.sonifications.values()))
+
+        if name not in self.sonifications:
+            raise KeyError(f"No sonification named '{name}' in this AudioFigure. "
+                           f"Choose from: {list(self.sonifications)}")
+
+        return self.sonifications[name]
+
+    def get_event_table(self, name=None, include_input=False):
+        """Get the table of events for a sonification.
+
+        Wrapper for
+        :meth:`~strauss.sonification.Sonification.event_table`, giving a
+        row per event with the time it sounds, the note played and the
+        value of each user-specified mapped parameter.
+
+        Args:
+          name (`optional`, :obj:`str`): name of the sonification. Can
+            be omitted where the figure holds only one.
+          include_input (`optional`, :obj:`bool`): if True, also give
+            the input data value of each parameter, before mapping.
+
+        Returns:
+          table (:obj:`pandas.DataFrame`): one row per event
+        """
+        return self._get_sonification(name).event_table(include_input=include_input)
+
+    def get_fixed_table(self, name=None):
+        """Get the table of unmapped parameters for a sonification.
+
+        Wrapper for
+        :meth:`~strauss.sonification.Sonification.fixed_table`, giving a
+        row per parameter that the user did not map, and the value it
+        takes.
+
+        Args:
+          name (`optional`, :obj:`str`): name of the sonification. Can
+            be omitted where the figure holds only one.
+
+        Returns:
+          table (:obj:`pandas.DataFrame`): one row per unmapped parameter
+        """
+        return self._get_sonification(name).fixed_table()
+
     def rename(self, old, new):
         dicts = [self.sonifications, self.levels, self.styles, self.figure_hashes]
         for d in dicts:

--- a/src/strauss/audio_figure.py
+++ b/src/strauss/audio_figure.py
@@ -368,7 +368,11 @@ class AudioFigure:
         for i in range(nmap, len(style.map)):
             mapping = style.map[i]
             if mapping.fixed is not None:
-                to_map.append(mapping.output)
+                if mapping.output in to_map:
+                    warnings.warn(f"'{mapping.output}' is mapped earlier in the "
+                                  f"style, but is being fixed at {mapping.fixed}.")
+                else:
+                    to_map.append(mapping.output)
                 origin[mapping.output] = 'fixed'
 
                 if mapping.output not in sources.spatial_angles:
@@ -388,14 +392,18 @@ class AudioFigure:
             if len(ksplit) > 1:
                 prop = ksplit[1]
                 if prop in to_map:
-                    print(f'Overwriting {prop} with fixed value...')
+                    # already mapped, so overwrite it in place rather than
+                    # mapping the same parameter twice
+                    warnings.warn(f"'{prop}' is mapped by the style, but is being "
+                                  f"overwritten with the fixed value {sonpars[k]}.")
+                else:
+                    to_map.append(prop)
                 map_data[prop] = [sonpars[k]]*len(map_data[to_map[0]])
                 # as above: angles are scaled and wrapped later
                 
                 if prop not in sources.spatial_angles:
                     in_lims[prop] = sources.param_lim_dict[prop]
                     out_lims[prop] = sources.param_lim_dict[prop]
-                to_map.append(prop)
                 origin[prop] = 'fixed'
 
        

--- a/src/strauss/audio_figure.py
+++ b/src/strauss/audio_figure.py
@@ -67,6 +67,9 @@ _kw_defaults = {
     # how events merged by max_notes_per_sec take their values, overriding
     # the style's own merge_mode where given
     'merge_mode': None,
+    # Treatment of non-finite (NaN or infinite) input data, overriding the
+    # style's own handle_nans where given
+    'handle_nans': None,
     # Style File
     'style' : None,
     'caption': None,
@@ -286,21 +289,39 @@ class AudioFigure:
             raise ValueError(f"merge_mode '{merge_mode}' is not recognised, "
                              "choose from 'average' or 'central'.")
 
+        # a handle_nans keyword overrides the style
+        handle_nans = sonpars['handle_nans'] or style.handle_nans
+        if handle_nans not in sources.nan_modes:
+            raise ValueError(f"handle_nans '{handle_nans}' is not recognised, "
+                             f"choose from {list(sources.nan_modes)}.")
+
         if (style.sources.lower() == 'events') and style.max_notes_per_sec:
+            # names are given per input event, so must be downsampled too
+            if (source_names is not None) and (len(source_names) != len(args[0])):
+                raise ValueError(f"Got {len(source_names)} source names for "
+                                 f"{len(args[0])} input events.")
+
             tdx = None
             for i, mapping in enumerate(data_maps):
                 if mapping.output == 'time':
                     tdx = i
-                    tlims = mapping.input_range
-                    tlims = set_limits(tlims, args[i], warn=False)
-                    time = rescale_values(args[i], tlims, (0,1))
                     break
 
-            # names are given per input event, so must be thinned alongside
-            # the data they name
-            if (source_names is not None) and (len(source_names) != len(args[0])):
-                raise ValueError(f"Got {len(source_names)} source names for "
-                                 f"{len(args[0])} input events.")
+            if tdx is not None:
+                # an event with no finite time has nowhere in the sonification
+                # to be placed, so cannot be sorted into a cluster to merge
+                # with. 
+                finite = np.isfinite(np.asarray(args[tdx], dtype=float))
+                if not finite.all():
+                    warnings.warn(f"Dropping {(~finite).sum()} events with a "
+                                  "non-finite 'time'")
+                    args = [np.asarray(a)[finite] for a in args]
+                    if source_names is not None:
+                        source_names = [n for n, f in zip(source_names, finite) if f]
+
+                tlims = data_maps[tdx].input_range
+                tlims = set_limits(tlims, args[tdx], warn=False)
+                time = rescale_values(args[tdx], tlims, (0,1))
 
             # azimuthal angles wrap around the circle, so must be merged as
             # directions. Any angle given an input_range is mapped linearly
@@ -416,7 +437,7 @@ class AudioFigure:
                 origin[prop] = 'fixed'
 
        
-        _sources = getattr(sources, style.sources.capitalize())(to_map)
+        _sources = getattr(sources, style.sources.capitalize())(to_map, handle_nans=handle_nans)
         _sources.origin = origin
 
         # report angles in whatever units they were given in, or in degrees
@@ -465,6 +486,7 @@ class AudioFigure:
             audio_setup=self.system,
             caption=sonpars["caption"],
             samprate=_generator.samprate, # Use generator's samprate for consistency
+            handle_nans=handle_nans,
         )
             
         name = self.add(_sonification, name=sonpars["name"], level=sonpars["level"])

--- a/src/strauss/presets/sampler/ranges/default.yml
+++ b/src/strauss/presets/sampler/ranges/default.yml
@@ -1,16 +1,16 @@
 # defaults parameter ranges for all mappable synth parameters
 
 # Numerical note length
-note_length: [1e-2, 30.]
+note_length: [1.0e-2, 30.]
 note_length_unit: 'seconds'
 
 # define the note volume envelope applied to the samples
 # A,D,S & R correspond to 'attack', 'decay', 'sustain' and 'release'
 volume_envelope:
-  A: [1e-2, 20.]
-  D: [1e-2, 20.]
+  A: [1.0e-2, 10.]
+  D: [1.0e-2, 10.]
   S: [0., 1.]
-  R: [1e-2, 20]
+  R: [1.0e-2, 10.]
   Ac: [-1. ,1.]
   Dc: [-1. ,1.]
   Rc: [-1. ,1.]
@@ -25,10 +25,10 @@ volume_envelope:
   level_unit: 'fraction'    
 
 volume_lfo:
-  A: [1e-2, 20.]
-  D: [1e-2, 20.]
+  A: [1.0e-2, 20.]
+  D: [1.0e-2, 20.]
   S: [0., 1.]
-  R: [1e-2, 20]
+  R: [1.0e-2, 20]
   Ac: [-1. ,1.]
   Dc: [-1. ,1.]
   Rc: [-1. ,1.]
@@ -44,14 +44,15 @@ volume_lfo:
   Dc_unit: 'unitless'
   Rc_unit: 'unitless'
   level_unit: 'fraction'    
+  amount_unit: 'fraction'
   freq_unit: 'Hz'
   freq_shift_unit: 'octave'
 
 pitch_lfo:
-  A: [1e-2, 20.]
-  D: [1e-2, 20.]
+  A: [1.0e-2, 20.]
+  D: [1.0e-2, 20.]
   S: [0., 1.]
-  R: [1e-2, 20]
+  R: [1.0e-2, 20]
   Ac: [-1. ,1.]
   Dc: [-1. ,1.]
   Rc: [-1. ,1.]
@@ -88,6 +89,10 @@ azimuth: [0., 1.]
 azimuth_unit: 'cycles'
 polar: [0.,1.]
 polar_unit: 'half-cycles'
+
+# stereo panning, as the fraction of amplitude from the right speaker
+pan: [0., 1.]
+pan_unit: 'fraction'
 
 # pitch range and default shift in semitones
 pitch_shift: [0., 24.]

--- a/src/strauss/presets/spec/ranges/default.yml
+++ b/src/strauss/presets/spec/ranges/default.yml
@@ -1,13 +1,17 @@
 # defaults parameter ranges for all mappable synth parameters
 
 # Numerical note length
-note_length: [1e-2, 30.]
+note_length: [1.0e-2, 30.]
 note_length_unit: 'seconds'
 
 azimuth: [0., 1.]
 azimuth_unit: 'cycles'
 polar: [0.,1.]
 polar_unit: 'half-cycles'
+
+# stereo panning, as the fraction of amplitude from the right speaker
+pan: [0., 1.]
+pan_unit: 'fraction'
 
 # pitch range and default shift in semitones
 pitch_shift: [0., 24.]
@@ -33,9 +37,9 @@ pitch_unit: 'unitless'
 
 # center panning:
 phi: [0., 1.]
-phi_unit: 'half-cycles (π)'
+phi_unit: 'cycles'
 theta: [0.,1.]
-theta_unit: 'cycles (2π)'
+theta_unit: 'half-cycles'
 
 # pitch range and default shift in semitones
 pitch_shift: [0., 24.]
@@ -49,10 +53,10 @@ cutoff: 1.
 # define the note volume envelope applied to the samples
 # A,D,S & R correspond to 'attack', 'decay', 'sustain' and 'release'
 volume_envelope:
-  A: [1e-2, 20.]
-  D: [1e-2, 20.]
+  A: [1.0e-2, 10.]
+  D: [1.0e-2, 10.]
   S: [0., 1.]
-  R: [1e-2, 20]
+  R: [1.0e-2, 10.]
   Ac: [-1. ,1.]
   Dc: [-1. ,1.]
   Rc: [-1. ,1.]
@@ -67,10 +71,10 @@ volume_envelope:
   level_unit: 'fraction'    
 
 volume_lfo:
-  A: [1e-2, 20.]
-  D: [1e-2, 20.]
+  A: [1.0e-2, 20.]
+  D: [1.0e-2, 20.]
   S: [0., 1.]
-  R: [1e-2, 20]
+  R: [1.0e-2, 20]
   Ac: [-1. ,1.]
   Dc: [-1. ,1.]
   Rc: [-1. ,1.]
@@ -86,14 +90,15 @@ volume_lfo:
   Dc_unit: 'unitless'
   Rc_unit: 'unitless'
   level_unit: 'fraction'    
+  amount_unit: 'fraction'
   freq_unit: 'Hz'
   freq_shift_unit: 'octave'
 
 pitch_lfo:
-  A: [1e-2, 20.]
-  D: [1e-2, 20.]
+  A: [1.0e-2, 20.]
+  D: [1.0e-2, 20.]
   S: [0., 1.]
-  R: [1e-2, 20]
+  R: [1.0e-2, 20]
   Ac: [-1. ,1.]
   Dc: [-1. ,1.]
   Rc: [-1. ,1.]

--- a/src/strauss/presets/synth/ranges/default.yml
+++ b/src/strauss/presets/synth/ranges/default.yml
@@ -1,16 +1,16 @@
 # defaults parameter ranges for all mappable synth parameters
 
 # Numerical note length
-note_length: [1e-2, 30.]
+note_length: [1.0e-2, 30.]
 note_length_unit: 'seconds'
 
 # define the note volume envelope applied to the samples
 # A,D,S & R correspond to 'attack', 'decay', 'sustain' and 'release'
 volume_envelope:
-  A: [1e-2, 20.]
-  D: [1e-2, 20.]
+  A: [1.0e-2, 10.]
+  D: [1.0e-2, 10.]
   S: [0., 1.]
-  R: [1e-2, 20]
+  R: [1.0e-2, 10.]
   Ac: [-1. ,1.]
   Dc: [-1. ,1.]
   Rc: [-1. ,1.]
@@ -25,10 +25,10 @@ volume_envelope:
   level_unit: 'fraction'    
 
 volume_lfo:
-  A: [1e-2, 20.]
-  D: [1e-2, 20.]
+  A: [1.0e-2, 20.]
+  D: [1.0e-2, 20.]
   S: [0., 1.]
-  R: [1e-2, 20]
+  R: [1.0e-2, 20]
   Ac: [-1. ,1.]
   Dc: [-1. ,1.]
   Rc: [-1. ,1.]
@@ -44,14 +44,15 @@ volume_lfo:
   Dc_unit: 'unitless'
   Rc_unit: 'unitless'
   level_unit: 'fraction'    
+  amount_unit: 'fraction'
   freq_unit: 'Hz'
   freq_shift_unit: 'octave'
 
 pitch_lfo:
-  A: [1e-2, 20.]
-  D: [1e-2, 20.]
+  A: [1.0e-2, 20.]
+  D: [1.0e-2, 20.]
   S: [0., 1.]
-  R: [1e-2, 20]
+  R: [1.0e-2, 20]
   Ac: [-1. ,1.]
   Dc: [-1. ,1.]
   Rc: [-1. ,1.]
@@ -90,6 +91,10 @@ azimuth: [0., 1.]
 azimuth_unit: 'cycles'
 polar: [0.,1.]
 polar_unit: 'half-cycles'
+
+# stereo panning, as the fraction of amplitude from the right speaker
+pan: [0., 1.]
+pan_unit: 'fraction'
 
 # pitch range and default shift in semitones
 pitch_shift: [0., 24.]

--- a/src/strauss/sonification.py
+++ b/src/strauss/sonification.py
@@ -303,11 +303,11 @@ class Sonification:
         :meth:`fixed_table`.
 
         Note:
-          The `time` column is the time of the event in the sonification,
-          in seconds, and so replaces any mapped `time` parameter (which
-          is a fraction of the sonification length). Where events have
-          been thinned by a `max_notes_per_sec` limit, rows represent the
-          events that sound rather than the input data points.
+          The `time` and `note` columns replace any mapped `time` and
+          `pitch` parameters, which are internal fractions rather than
+          what is heard - `time` is the time of the event in the
+          sonification in seconds, and `note` the note it ultimately
+          sounds.
 
         Args:
           include_input (`optional`, :obj:`bool`): if True, also give the
@@ -328,8 +328,9 @@ class Sonification:
         for key in self.sources.mapped_quantities:
             if self.sources.origin.get(key, 'mapped') != 'mapped':
                 continue
-            if key not in ('time', 'time_evo'):
-                # time is already the index of each row
+            if key not in ('time', 'time_evo', 'pitch'):
+                # time and pitch are already given by the time and note
+                # of each row, in the terms actually heard
                 table[key] = np.asarray(self.sources.mapped_samples[key])
             if include_input:
                 table[f'{key}_input'] = np.asarray(self.sources.raw_mapping[key])

--- a/src/strauss/sonification.py
+++ b/src/strauss/sonification.py
@@ -303,6 +303,7 @@ class Sonification:
         excluded, and are instead listed by :meth:`fixed_table`.
 
         Note:
+          Rows are ordered in time, whatever order the data was given in.
           The `time` and `note` columns replace any mapped `time` and
           `pitch` parameters, which are internal fractions rather than
           what is heard - `time` is the time of the event in the
@@ -340,7 +341,9 @@ class Sonification:
             if include_input:
                 table[f'{key}_input'] = np.asarray(self.sources.raw_mapping[key])
 
-        return pd.DataFrame(table)
+
+        return pd.DataFrame(table).sort_values('time', kind='stable',
+                                               ignore_index=True)
 
     def _resolve_source(self, source=None):
         """Resolve a source name or index, defaulting to a lone source.
@@ -375,6 +378,7 @@ class Sonification:
         :meth:`fixed_table`.
 
         Note:
+          Rows are ordered in time, whatever order the data was given in.
           As for :meth:`event_table`, `time` is given in seconds, and
           replaces the mapped `time_evo` parameter, and spatial angles
           are given in degrees, or in the sonification's `angle_unit`
@@ -429,7 +433,9 @@ class Sonification:
             if include_input:
                 table[f'{key}_input'] = _down_column(self.sources.raw_mapping[key][index])
 
-        table = pd.DataFrame(table)
+
+        table = pd.DataFrame(table).sort_values('time', kind='stable',
+                                                ignore_index=True)
 
         notes, _ = self._assign_notes()
         table.attrs['source'] = self.sources.names[index]

--- a/src/strauss/sonification.py
+++ b/src/strauss/sonification.py
@@ -15,7 +15,9 @@ Todo:
 
 from .stream import Stream
 from .channels import audio_channels
-from .sources import Events, Objects
+from .sources import (Events, Objects, spatial_angles, display_name,
+                      param_converters, param_lim_dict)
+from .utilities import decimals_for_range
 from .utilities import const_or_evo, nested_dict_idx_reassign, apply_fades, rescale_values, NoSoundDevice, is_notebook
 from .tts_caption import render_caption, get_ttsMode, default_tts_voice
 import numpy as np
@@ -293,6 +295,165 @@ class Sonification:
             raise Exception("Sources have no mapped values to tabulate - run "
                             "'apply_mapping_functions' on the sources first.")
 
+    def _param_unit(self, key):
+        """The unit a mapped parameter is reported in.
+
+        Units come from three places, in order: the table columns that
+        replace a mapped parameter with what is heard (`time` in
+        seconds, `note` in place of `pitch`), the units spatial angles
+        are reported in, and otherwise the `<parameter>_unit` entries of
+        the :obj:`Generator` ranges. Anything else, and anything the
+        ranges call `unitless`, has no unit to report.
+
+        Args:
+          key (:obj:`str`): name of the mapped parameter, or of a table
+            column
+
+        Returns:
+          unit (:obj:`str`): the unit, or an empty string where the
+          quantity has none
+        """
+        if key in param_converters:
+            # the value is converted for reporting, so takes the unit of
+            # whatever it is converted into
+            return param_converters[key][1]
+
+        if key in spatial_angles:
+            return self.sources.table_angle_unit or 'degrees'
+
+        # otherwise ask the generator what it calls this parameter's units
+        node = self.generator.preset.get('ranges', {})
+        parts = key.split('/')
+        for part in parts[:-1]:
+            node = node.get(part, {})
+            if not isinstance(node, dict):
+                return ''
+        unit = node.get(f'{parts[-1]}_unit', '')
+
+        return '' if unit == 'unitless' else unit
+
+    def _display_values(self, key, values):
+        """Put mapped values into the terms they are reported in.
+
+        A mapped value is not always the quantity worth reporting - a
+        spatial angle is a fraction of a turn rather than an angle, and
+        `pan` a fraction rather than a share of the output. Parameters
+        with an entry in `param_converters` are converted by it, and
+        spatial angles by the units angles are reported in. Anything
+        else is already in the terms it is reported in.
+
+        Args:
+          key (:obj:`str`): name of the mapped parameter
+          values (:obj:`array-like` or :obj:`float`): mapped values
+
+        Returns:
+          values (:obj:`array-like` or :obj:`float`): the values as they
+          are reported
+        """
+        if key in param_converters:
+            convert, _ = param_converters[key]
+            return convert(values)
+
+        return self.sources.in_angle_unit(key, values)
+
+    def _display_range(self, key):
+        """The range a parameter covers, as it is reported.
+
+        Args:
+          key (:obj:`str`): name of the mapped parameter
+
+        Returns:
+          span (:obj:`float`): the range it covers, or `None` where the
+          parameter has no known limits
+        """
+        if key in ('time', 'time_evo'):
+            return float(self.score.length)
+
+        lims = self.sources.plims.get(key, param_lim_dict.get(key))
+        if lims is None:
+            return None
+
+        lims = np.asarray(self._display_values(key, np.asarray(lims)),
+                          dtype=float)
+
+        return float(abs(np.diff(lims)[0]))
+
+    def _round_numbers(self, table):
+        """Round a table's numbers to what is worth reading.
+
+        Each column is rounded to the decimal places that resolve its
+        range into a thousand steps, so that a column of angles in
+        degrees is given to a tenth of a degree and the same angles in
+        cycles to a thousandth. Columns whose range is unknown, input
+        data among them, are resolved by the values they hold. Times are
+        never coarser than 10 ms, however long the sonification.
+
+        Args:
+          table (:obj:`pandas.DataFrame`): table to round
+
+        Returns:
+          table (:obj:`pandas.DataFrame`): the same table, rounded
+        """
+        for name in table.columns:
+            if not pd.api.types.is_numeric_dtype(table[name]):
+                continue
+
+            values = table[name].to_numpy(dtype=float)
+
+            span = self._display_range(name)
+            if span is None:
+                # no declared range, as for input data in the user's own
+                # units, so resolve what the column holds
+                finite = values[np.isfinite(values)]
+                span = float(finite.max() - finite.min()) if finite.size else 0.
+
+            decimals = decimals_for_range(span)
+            if name in ('time', 'time_evo'):
+                # times keep to the nearest 10 ms however long the
+                # sonification, rather than coarsening with its length
+                decimals = max(decimals, 2)
+
+            table[name] = np.round(values, decimals)
+
+        return table
+
+    def _with_units(self, table):
+        """Label a table's columns with the units of their contents.
+
+        Columns become a two-level :obj:`pandas.MultiIndex` of name and
+        unit, so that units travel with the table rather than living in
+        its formatting - they survive `to_csv`, and are read back with
+        `header=[0,1]`.
+
+        Note:
+          Columns holding no numerical quantity (e.g. `source`, `note`)
+          and input data columns, whose units are the user's own, are
+          labelled with an empty unit.
+
+        Args:
+          table (:obj:`pandas.DataFrame`): table with plain columns
+
+        Returns:
+          table (:obj:`pandas.DataFrame`): the same table, with name and
+          unit columns
+        """
+        names, units = [], []
+        for column in table.columns:
+            if column.endswith('_input'):
+                # input values are the data as given, in the user's own units
+                key = column[:-len('_input')]
+                names.append(f'{display_name(key)} (input)')
+                units.append('')
+            else:
+                names.append(display_name(column))
+                unit = self._param_unit(column)
+                # bracket it, to read as a unit rather than as a second name
+                units.append(f'[{unit}]' if unit else '')
+
+        table.columns = pd.MultiIndex.from_arrays([names, units])
+
+        return table
+
     def event_table(self, include_input=False):
         """Tabulate the events of the sonification.
 
@@ -328,7 +489,9 @@ class Sonification:
         notes, times = self._assign_notes()
 
         # each event is a source, so is named by it
-        table = {'source': self.sources.names, 'time': times, 'note': notes}
+        table = {'source': self.sources.names,
+                 'time': self._display_values('time', times),
+                 'note': notes}
 
         for key in self.sources.mapped_quantities:
             if self.sources.origin.get(key, 'mapped') != 'mapped':
@@ -336,14 +499,16 @@ class Sonification:
             if key not in ('time', 'time_evo', 'pitch'):
                 # time and pitch are already given by the time and note
                 # of each row, in the terms actually heard
-                table[key] = self.sources.in_angle_unit(
+                table[key] = self._display_values(
                     key, np.asarray(self.sources.mapped_samples[key]))
             if include_input:
                 table[f'{key}_input'] = np.asarray(self.sources.raw_mapping[key])
 
 
-        return pd.DataFrame(table).sort_values('time', kind='stable',
-                                               ignore_index=True)
+        table = pd.DataFrame(table).sort_values('time', kind='stable',
+                                                ignore_index=True)
+
+        return self._with_units(self._round_numbers(table))
 
     def _resolve_source(self, source=None):
         """Resolve a source name or index, defaulting to a lone source.
@@ -409,7 +574,7 @@ class Sonification:
         # single unchanging state
         if 'time_evo' in self.sources.mapped_samples:
             times = np.asarray(self.sources.mapped_samples['time_evo'][index])
-            times = times * self.score.length
+            times = self._display_values('time', times * self.score.length)
         else:
             times = np.zeros(1)
 
@@ -428,7 +593,7 @@ class Sonification:
             if key not in ('time', 'time_evo', 'pitch'):
                 # time and pitch are already given by the time column and
                 # the note of the object, in the terms actually heard
-                table[key] = self.sources.in_angle_unit(
+                table[key] = self._display_values(
                     key, _down_column(self.sources.mapped_samples[key][index]))
             if include_input:
                 table[f'{key}_input'] = _down_column(self.sources.raw_mapping[key][index])
@@ -436,6 +601,7 @@ class Sonification:
 
         table = pd.DataFrame(table).sort_values('time', kind='stable',
                                                 ignore_index=True)
+        table = self._with_units(self._round_numbers(table))
 
         notes, _ = self._assign_notes()
         table.attrs['source'] = self.sources.names[index]
@@ -498,11 +664,20 @@ class Sonification:
                 # not held at one value, so don't claim it is
                 continue
 
-            rows.append({'parameter': name,
-                         'value': self.sources.in_angle_unit(key, values[0]),
+            value = self._display_values(key, values[0])
+
+            rows.append({'parameter': display_name(name),
+                         'value': value if isinstance(value, str) else
+                                  round(float(value),
+                                        decimals_for_range(
+                                            self._display_range(key) or 0.)),
+                         # a row per parameter, so the unit is a column of its
+                         # own rather than a second level of the column names
+                         'unit': self._param_unit(name),
                          'origin': origin})
 
-        return pd.DataFrame(rows, columns=['parameter', 'value', 'origin'])
+        return pd.DataFrame(rows, columns=['parameter', 'value', 'unit',
+                                           'origin'])
 
     def add_ticks(self, increment, duration=0.04, tick_vol=0.25):
         # TODO this should probably use a dedicated generator...

--- a/src/strauss/sonification.py
+++ b/src/strauss/sonification.py
@@ -15,7 +15,7 @@ Todo:
 
 from .stream import Stream
 from .channels import audio_channels
-from .sources import Events
+from .sources import Events, Objects
 from .utilities import const_or_evo, nested_dict_idx_reassign, apply_fades, rescale_values, NoSoundDevice, is_notebook
 from .tts_caption import render_caption, get_ttsMode, default_tts_voice
 import numpy as np
@@ -296,18 +296,19 @@ class Sonification:
     def event_table(self, include_input=False):
         """Tabulate the events of the sonification.
 
-        Produces a table with a row per event, giving the time at which
-        it sounds, the note played, and the value of each user-specified
-        mapped parameter. Parameters added automatically or held at fixed
-        values are excluded, and are instead listed by
-        :meth:`fixed_table`.
+        Produces a table with a row per event, giving the name of the
+        source it represents, the time at which it sounds, the note
+        played, and the value of each user-specified mapped parameter.
+        Parameters added automatically or held at fixed values are
+        excluded, and are instead listed by :meth:`fixed_table`.
 
         Note:
           The `time` and `note` columns replace any mapped `time` and
           `pitch` parameters, which are internal fractions rather than
           what is heard - `time` is the time of the event in the
           sonification in seconds, and `note` the note it ultimately
-          sounds.
+          sounds. Spatial angles are given in the sonification's
+          `angle_unit` rather than as mapped fractions.
 
         Args:
           include_input (`optional`, :obj:`bool`): if True, also give the
@@ -323,7 +324,9 @@ class Sonification:
                             f"sources are {type(self.sources).__name__}.")
 
         notes, times = self._assign_notes()
-        table = {'time': times, 'note': notes}
+
+        # each event is a source, so is named by it
+        table = {'source': self.sources.names, 'time': times, 'note': notes}
 
         for key in self.sources.mapped_quantities:
             if self.sources.origin.get(key, 'mapped') != 'mapped':
@@ -331,13 +334,108 @@ class Sonification:
             if key not in ('time', 'time_evo', 'pitch'):
                 # time and pitch are already given by the time and note
                 # of each row, in the terms actually heard
-                table[key] = np.asarray(self.sources.mapped_samples[key])
+                table[key] = self.sources.in_angle_unit(
+                    key, np.asarray(self.sources.mapped_samples[key]))
             if include_input:
                 table[f'{key}_input'] = np.asarray(self.sources.raw_mapping[key])
 
         return pd.DataFrame(table)
 
-    def fixed_table(self):
+    def _resolve_source(self, source=None):
+        """Resolve a source name or index, defaulting to a lone source.
+
+        Args:
+          source (`optional`, :obj:`str` or :obj:`int`): name or index of
+            the source. Can be omitted where there is only one.
+
+        Returns:
+          index (:obj:`int`): index of the source
+
+        Raises:
+          KeyError: if omitted where there is more than one source.
+        """
+        if source is None:
+            if self.sources.n_sources > 1:
+                raise KeyError("Sonification has more than one source, so a "
+                               "'source' is needed. Choose from: "
+                               f"{self.sources.names}")
+            return 0
+
+        return self.sources.source_index(source)
+
+    def object_table(self, source=None, include_input=False):
+        """Tabulate the evolution of one object of the sonification.
+
+        Produces a table for a single source, with a row per point in
+        its continuous evolution, giving the time and the value of each
+        user-specified mapped parameter at that point. Parameters that
+        do not evolve hold the same value down their column. Those the
+        user did not map are excluded, and are instead listed by
+        :meth:`fixed_table`.
+
+        Note:
+          As for :meth:`event_table`, `time` is given in seconds, and
+          replaces the mapped `time_evo` parameter, and spatial angles
+          are given in the sonification's `angle_unit`. The note the
+          object plays, and its name, are given by the `note` and
+          `source` entries of the table's `attrs`.
+
+        Args:
+          source (`optional`, :obj:`str` or :obj:`int`): name or index
+            of the source, as in :attr:`Source.names`. Can be omitted
+            where the sonification has only one source.
+          include_input (`optional`, :obj:`bool`): if True, also give the
+            input data value of each parameter, before mapping, in a
+            column suffixed `'_input'`.
+
+        Returns:
+          table (:obj:`pandas.DataFrame`): one row per point in the
+          object's evolution
+        """
+        self._check_can_tabulate()
+        if not isinstance(self.sources, Objects):
+            raise TypeError(f"'object_table' is for Objects sources, but these "
+                            f"sources are {type(self.sources).__name__}.")
+
+        index = self._resolve_source(source)
+
+        # objects with nothing evolving have no time base, and so are a
+        # single unchanging state
+        if 'time_evo' in self.sources.mapped_samples:
+            times = np.asarray(self.sources.mapped_samples['time_evo'][index])
+            times = times * self.score.length
+        else:
+            times = np.zeros(1)
+
+        def _down_column(values):
+            """Broadcast an unevolving value down the time column."""
+            values = np.asarray(values)
+            if values.ndim == 0:
+                return np.broadcast_to(values, times.shape)
+            return values
+
+        table = {'time': times}
+
+        for key in self.sources.mapped_quantities:
+            if self.sources.origin.get(key, 'mapped') != 'mapped':
+                continue
+            if key not in ('time', 'time_evo', 'pitch'):
+                # time and pitch are already given by the time column and
+                # the note of the object, in the terms actually heard
+                table[key] = self.sources.in_angle_unit(
+                    key, _down_column(self.sources.mapped_samples[key][index]))
+            if include_input:
+                table[f'{key}_input'] = _down_column(self.sources.raw_mapping[key][index])
+
+        table = pd.DataFrame(table)
+
+        notes, _ = self._assign_notes()
+        table.attrs['source'] = self.sources.names[index]
+        table.attrs['note'] = notes[index]
+
+        return table
+
+    def fixed_table(self, source=None):
         """Tabulate parameters the user did not map.
 
         Companion to :meth:`event_table`, listing the parameters the
@@ -347,26 +445,39 @@ class Sonification:
         the value each takes.
 
         Note:
-          Parameters varying from source to source (e.g. the `pitch`
-          assigned to each Object of a chord) have no one value to
-          report, and are left out.
+          Across the whole sonification, parameters varying from source
+          to source (e.g. the `pitch` assigned to each Object of a
+          chord) have no one value to report, and are left out. Given a
+          `source`, they take their value for that source, so are
+          listed. Spatial angles are given in the sonification's
+          `angle_unit`.
+
+        Args:
+          source (`optional`, :obj:`str` or :obj:`int`): name or index
+            of a source, as in :attr:`Source.names`, to report values
+            for. If omitted, values are reported for the sonification as
+            a whole.
 
         Returns:
           table (:obj:`pandas.DataFrame`): one row per unmapped parameter
         """
         self._check_can_tabulate()
 
+        index = None if source is None else self._resolve_source(source)
+
         rows = []
         for key in self.sources.mapped_quantities:
             origin = self.sources.origin.get(key, 'mapped')
             if origin == 'mapped':
                 continue
-            values = np.unique(np.asarray(self.sources.mapped_samples[key]))
+            values = self.sources.mapped_samples[key]
+            values = np.unique(np.asarray(values if index is None
+                                          else values[index]))
             if values.size != 1:
                 # not held at one value, so don't claim it is
                 continue
             rows.append({'parameter': key,
-                         'value': values[0],
+                         'value': self.sources.in_angle_unit(key, values[0]),
                          'origin': origin})
 
         return pd.DataFrame(rows, columns=['parameter', 'value', 'origin'])

--- a/src/strauss/sonification.py
+++ b/src/strauss/sonification.py
@@ -15,9 +15,11 @@ Todo:
 
 from .stream import Stream
 from .channels import audio_channels
+from .sources import Events
 from .utilities import const_or_evo, nested_dict_idx_reassign, apply_fades, rescale_values, NoSoundDevice, is_notebook
 from .tts_caption import render_caption, get_ttsMode, default_tts_voice
 import numpy as np
+import pandas as pd
 import matplotlib.pyplot as plt
 import sys
 import os
@@ -129,6 +131,57 @@ class Sonification:
             elif isinstance(self.out_channels[chan], np.ndarray):
                 self.out_channels[chan][:] = 0.
             
+    def _assign_notes(self):
+        """Determine the note played by each source, and when.
+
+        Combines the :obj:`Sources` `time` and `pitch` mappings with the
+        :obj:`Score` chord sequence to decide which note each source
+        sounds, and at what point in the sonification. Used by
+        :meth:`render`, and by the table methods so that a table can be
+        produced without rendering any audio.
+
+        Note:
+          As in :meth:`render`, sources with no `time` mapping are all
+          assumed to start at zero and last the full sonification.
+
+        Returns:
+          notes (:obj:`list(str)`): note played by each source, in
+            scientific pitch notation (e.g. :obj:`'A4'`)
+          times (:obj:`ndarray`): start time of each source in seconds
+        """
+        # determine if time is provided, if not assume all start at zero
+        # and last the duration of sonification
+        if "time" not in self.sources.mapping:
+            self.sources.mapping['time'] = [0.] * self.sources.n_sources
+            self.sources.mapping['note_length'] = [self.score.length] * self.sources.n_sources
+
+        # index each chord
+        cbin = np.digitize(self.sources.mapping['time'], self.score.fracbins, 0)
+        cbin = np.clip(cbin-1, 0, self.score.nchords-1)
+
+        # pitch rank of each source divided by the number of sources
+        pitch = np.asarray(self.sources.mapping['pitch'])
+        pitchfrac = np.empty_like(pitch)
+        if self.score.pitch_binning == 'adaptive' and np.unique(pitch).size > 1:
+            idxs = np.argsort(pitch)
+            pitchfrac[idxs] = np.arange(self.sources.n_sources)/self.sources.n_sources
+        else:
+            # a single pitch value has no ranking to adapt to - ranking it
+            # would spread sources over the chord in whatever order they
+            # arrived in, so bin it as a fixed pitch, as uniform binning does
+            pitchfrac = np.clip(pitch, 0, 9.999999e-1)
+
+        notes = []
+        for source in range(self.sources.n_sources):
+            chord = self.score.note_sequence[cbin[source]]
+            nints = self.score.nintervals[cbin[source]]
+            notes.append(chord[int(pitchfrac[source] * nints)])
+
+        # mapped time is a fraction of the sonification length
+        times = np.array(self.sources.mapping['time']) * self.score.length
+
+        return notes, times
+
     def render(self, downsamp=1, progress=True):
         """Render the sonification.
         
@@ -148,24 +201,10 @@ class Sonification:
         # first, clear the audio channels
         self.clear()
         
-        # determine if time is provided, if not assume all start at zero
-        # and last the duration of sonification
+        # determine the note played by each source and when it starts
+        # (this also defaults the time mapping, if none was provided)
+        notes, _ = self._assign_notes()
 
-        if "time" not in self.sources.mapping:
-            self.sources.mapping['time'] = [0.] * self.sources.n_sources
-            self.sources.mapping['note_length'] = [self.score.length] * self.sources.n_sources
-            
-        # index each chord
-        cbin = np.digitize(self.sources.mapping['time'], self.score.fracbins, 0)
-        cbin = np.clip(cbin-1, 0, self.score.nchords-1)
-
-        # pitch rank of each source divided by the number of sources
-        pitchfrac = np.empty_like(self.sources.mapping['pitch'])
-        if self.score.pitch_binning == 'adaptive':
-            pitchfrac[np.argsort(self.sources.mapping['pitch'])] = np.arange(self.sources.n_sources)/self.sources.n_sources
-        elif self.score.pitch_binning == 'uniform':
-            pitchfrac = np.clip(self.sources.mapping['pitch'], 0, 9.999999e-1)
-            
         # get some relevant numbers before iterating through sources
         Nsamp = self.out_channels['0'].values.size
         lastsamp = Nsamp - 1
@@ -179,10 +218,7 @@ class Sonification:
             # index note properties
             t = self.sources.mapping['time'][source]
             tsamp = int((Nsamp-1) * t)
-            chord = self.score.note_sequence[cbin[source]]
-            nints = self.score.nintervals[cbin[source]]
-            pitch = pitchfrac[source]
-            note = chord[int(pitch * nints)]
+            note = notes[source]
 
             # make dictionary for feeding to play function with each notes properties
             sourcemap = {}
@@ -250,6 +286,89 @@ class Sonification:
             for c in range(Nchan):
                 self.caption_channels[str(c)] = Stream(0, self.samprate) 
 
+
+    def _check_can_tabulate(self):
+        """Check the sources carry the mapped values a table needs."""
+        if not getattr(self.sources, 'mapped_samples', {}):
+            raise Exception("Sources have no mapped values to tabulate - run "
+                            "'apply_mapping_functions' on the sources first.")
+
+    def event_table(self, include_input=False):
+        """Tabulate the events of the sonification.
+
+        Produces a table with a row per event, giving the time at which
+        it sounds, the note played, and the value of each user-specified
+        mapped parameter. Parameters added automatically or held at fixed
+        values are excluded, and are instead listed by
+        :meth:`fixed_table`.
+
+        Note:
+          The `time` column is the time of the event in the sonification,
+          in seconds, and so replaces any mapped `time` parameter (which
+          is a fraction of the sonification length). Where events have
+          been thinned by a `max_notes_per_sec` limit, rows represent the
+          events that sound rather than the input data points.
+
+        Args:
+          include_input (`optional`, :obj:`bool`): if True, also give the
+            input data value of each parameter, before mapping, in a
+            column suffixed `'_input'`.
+
+        Returns:
+          table (:obj:`pandas.DataFrame`): one row per event
+        """
+        self._check_can_tabulate()
+        if not isinstance(self.sources, Events):
+            raise TypeError(f"'event_table' is for Events sources, but these "
+                            f"sources are {type(self.sources).__name__}.")
+
+        notes, times = self._assign_notes()
+        table = {'time': times, 'note': notes}
+
+        for key in self.sources.mapped_quantities:
+            if self.sources.origin.get(key, 'mapped') != 'mapped':
+                continue
+            if key not in ('time', 'time_evo'):
+                # time is already the index of each row
+                table[key] = np.asarray(self.sources.mapped_samples[key])
+            if include_input:
+                table[f'{key}_input'] = np.asarray(self.sources.raw_mapping[key])
+
+        return pd.DataFrame(table)
+
+    def fixed_table(self):
+        """Tabulate parameters the user did not map.
+
+        Companion to :meth:`event_table`, listing the parameters the
+        user did not map - those held at a fixed value, and those
+        STRAUSS assigned itself where no mapping was given (`'fixed'`
+        and `'auto'` in the `origin` column, respectively) - alongside
+        the value each takes.
+
+        Note:
+          Parameters varying from source to source (e.g. the `pitch`
+          assigned to each Object of a chord) have no one value to
+          report, and are left out.
+
+        Returns:
+          table (:obj:`pandas.DataFrame`): one row per unmapped parameter
+        """
+        self._check_can_tabulate()
+
+        rows = []
+        for key in self.sources.mapped_quantities:
+            origin = self.sources.origin.get(key, 'mapped')
+            if origin == 'mapped':
+                continue
+            values = np.unique(np.asarray(self.sources.mapped_samples[key]))
+            if values.size != 1:
+                # not held at one value, so don't claim it is
+                continue
+            rows.append({'parameter': key,
+                         'value': values[0],
+                         'origin': origin})
+
+        return pd.DataFrame(rows, columns=['parameter', 'value', 'origin'])
 
     def add_ticks(self, increment, duration=0.04, tick_vol=0.25):
         # TODO this should probably use a dedicated generator...

--- a/src/strauss/sonification.py
+++ b/src/strauss/sonification.py
@@ -458,7 +458,9 @@ class Sonification:
           chord) have no one value to report, and are left out. Given a
           `source`, they take their value for that source, so are
           listed. Spatial angles are given in degrees, or in the
-          sonification's `angle_unit` where one was asked for.
+          sonification's `angle_unit` where one was asked for. A `pitch`
+          is reported as the `note` it resolves to, being what is
+          ultimately heard.
 
         Args:
           source (`optional`, :obj:`str` or :obj:`int`): name or index
@@ -478,13 +480,25 @@ class Sonification:
             origin = self.sources.origin.get(key, 'mapped')
             if origin == 'mapped':
                 continue
-            values = self.sources.mapped_samples[key]
-            values = np.unique(np.asarray(values if index is None
-                                          else values[index]))
-            if values.size != 1:
+
+            if key == 'pitch':
+                # a mapped pitch is an internal fraction, of no use to the
+                # reader - what is heard is the note it resolves to
+                notes, _ = self._assign_notes()
+                values = np.unique(notes if index is None else [notes[index]])
+                values = values.astype(str).tolist()
+                name = 'note'
+            else:
+                values = self.sources.mapped_samples[key]
+                values = np.unique(np.asarray(values if index is None
+                                              else values[index]))
+                name = key
+
+            if len(values) != 1:
                 # not held at one value, so don't claim it is
                 continue
-            rows.append({'parameter': key,
+
+            rows.append({'parameter': name,
                          'value': self.sources.in_angle_unit(key, values[0]),
                          'origin': origin})
 

--- a/src/strauss/sonification.py
+++ b/src/strauss/sonification.py
@@ -30,6 +30,7 @@ import wavio as wav
 import IPython.display as ipd
 from IPython.display import display
 from scipy.io import wavfile
+from scipy.interpolate import interp1d
 import warnings
 import tempfile
 from pathlib import Path
@@ -60,7 +61,7 @@ class Sonification:
     """
     def __init__(self, score, sources, generator, audio_setup='stereo',
                  caption=None, samprate=48000, declick_time=0.03,
-                 ttsmodel=default_tts_voice):
+                 ttsmodel=default_tts_voice, handle_nans=None):
         """
         Args:
          score (:class:`~strauss.score.Score`): Sonification :obj:`Score`
@@ -81,9 +82,15 @@ class Sonification:
           on save and dispolay to remove audible clicks from sample
           discontinuity
          ttsmodel (:obj:`str` or :obj:`PosixPath`) file path to the
-          text-to-speech model used for captions. 
+          text-to-speech model used for captions.
+         handle_nans (:obj:`str`) how to treat the audio any source's
+          non-finite data corresponds to, either :obj:`'silent'` or
+          :obj:`'interpolate'`. Taken from the :obj:`Sources` where not
+          given, which is where the data itself is handled - see the
+          `handle_nans` argument of
+          :meth:`~strauss.sources.Source.__init__`.
         """
-        
+
         # sampling rate in Hz
         self.samprate = samprate
         
@@ -104,7 +111,17 @@ class Sonification:
 
         # sonification owns an instance of the Generator
         self.generator = generator
-        
+
+        # the Sources handle the data, and so decide what is
+        # interpolated and which events sound - from here these
+        # instructions are taken to part-mute or drop sources.
+        self.handle_nans = handle_nans or self.sources.handle_nans
+        if handle_nans and (handle_nans != self.sources.handle_nans):
+            warnings.warn(f"handle_nans='{handle_nans}' disagrees with the "
+                          f"Sources value of '{self.sources.handle_nans}', "
+                          "which has already been applied to the data. Pass " 
+                          "to the Sources too for correct behaviour.")
+
         # set up the audio channel routing for the sonification
         self.channels = audio_channels(setup=audio_setup)
 
@@ -215,7 +232,13 @@ class Sonification:
 
         if progress:
             print('Processing sonification..')
+        mute_nans = (self.handle_nans == 'silent')
+
         for source in tqdm(indices) if progress else indices:
+
+            # a source with no data at all has nothing to sound, so skip
+            if mute_nans and self.sources.all_missing(source):
+                continue
 
             # index note properties
             t = self.sources.mapping['time'][source]
@@ -233,6 +256,26 @@ class Sonification:
             # run generator to play each note
             sstream = self.generator.play(sourcemap)
             playlen = sstream.values.size
+
+            # silence the stretches the source has no data for, ramping in
+            # and out so the gaps don't click. Applied before spatialisation
+            # so that it costs one multiply rather than one per channel
+            if mute_nans:
+                nlength = sourcemap.get('note_length',
+                                        self.generator.preset.get('note_length'))
+                if not isinstance(nlength, (int, float, np.number)) or (nlength <= 0):
+                    # the sampler's 'sample' length runs as long as the sample
+                    nlength = playlen/self.samprate
+                knots = self.sources.mute_envelope(source,
+                                                   self.declick_time/nlength)
+                if knots is not None:
+                    x, y = knots
+                    # as with the evolving parameters, the curve is read at
+                    # the sample fractions of the note, holding its end value
+                    # through the release tail
+                    mutenv = interp1d(x, y, bounds_error=False,
+                                      fill_value=(y[0], y[-1]))
+                    sstream.values = sstream.values * mutenv(sstream.sampfracs)
 
             # place source on listener plane (quarter rotation) by default
             polar = 0.5 * np.pi
@@ -395,6 +438,9 @@ class Sonification:
           table (:obj:`pandas.DataFrame`): the same table, rounded
         """
         for name in table.columns:
+            # Avoid rounding booleans to e.g. 1.0
+            if pd.api.types.is_bool_dtype(table[name]):
+                continue
             if not pd.api.types.is_numeric_dtype(table[name]):
                 continue
 
@@ -493,6 +539,10 @@ class Sonification:
                  'time': self._display_values('time', times),
                  'note': notes}
 
+        # flag the events sounding using interpolated values
+        if (self.sources.nan_mask is not None) and np.any(self.sources.nan_mask):
+            table['missing'] = np.asarray(self.sources.nan_mask, dtype=bool)
+
         for key in self.sources.mapped_quantities:
             if self.sources.origin.get(key, 'mapped') != 'mapped':
                 continue
@@ -586,6 +636,11 @@ class Sonification:
             return values
 
         table = {'time': times}
+
+        # flag the points sounding at interpolated values
+        if (self.sources.nan_mask is not None) and np.any(self.sources.nan_mask[index]):
+            table['missing'] = _down_column(
+                np.asarray(self.sources.nan_mask[index], dtype=bool))
 
         for key in self.sources.mapped_quantities:
             if self.sources.origin.get(key, 'mapped') != 'mapped':

--- a/src/strauss/sonification.py
+++ b/src/strauss/sonification.py
@@ -307,8 +307,9 @@ class Sonification:
           `pitch` parameters, which are internal fractions rather than
           what is heard - `time` is the time of the event in the
           sonification in seconds, and `note` the note it ultimately
-          sounds. Spatial angles are given in the sonification's
-          `angle_unit` rather than as mapped fractions.
+          sounds. Spatial angles are given in degrees, or in the
+          sonification's `angle_unit` where one was asked for, rather
+          than as mapped fractions.
 
         Args:
           include_input (`optional`, :obj:`bool`): if True, also give the
@@ -376,7 +377,8 @@ class Sonification:
         Note:
           As for :meth:`event_table`, `time` is given in seconds, and
           replaces the mapped `time_evo` parameter, and spatial angles
-          are given in the sonification's `angle_unit`. The note the
+          are given in degrees, or in the sonification's `angle_unit`
+          where one was asked for. The note the
           object plays, and its name, are given by the `note` and
           `source` entries of the table's `attrs`.
 
@@ -449,8 +451,8 @@ class Sonification:
           to source (e.g. the `pitch` assigned to each Object of a
           chord) have no one value to report, and are left out. Given a
           `source`, they take their value for that source, so are
-          listed. Spatial angles are given in the sonification's
-          `angle_unit`.
+          listed. Spatial angles are given in degrees, or in the
+          sonification's `angle_unit` where one was asked for.
 
         Args:
           source (`optional`, :obj:`str` or :obj:`int`): name or index

--- a/src/strauss/sources.py
+++ b/src/strauss/sources.py
@@ -94,6 +94,7 @@ param_lim_dict = dict(zip(mappable, param_limits))
 
 spatial_angles = ('azimuth', 'polar', 'theta', 'phi')
 z_angles = ('polar', 'theta')
+azimuthal_angles = ('azimuth', 'phi')
 angle_unit_maxs = {'degrees': 360,
                    'radians': 2*np.pi,
                    'cycles': 1}

--- a/src/strauss/sources.py
+++ b/src/strauss/sources.py
@@ -230,6 +230,34 @@ class Source:
 
         return names.index(source)
 
+    def in_angle_unit(self, key, values):
+        """Express mapped values of a spatial angle in its input unit.
+
+        Spatial angles are mapped to a fraction of the angular range
+        they span, as this is what the sonification works in. This
+        converts such values back to the unit they were given in (see
+        the `angle_unit` argument of :meth:`apply_mapping_functions`),
+        leaving any other parameter alone.
+
+        Args:
+          key (:obj:`str`): name of the mapped parameter
+          values (:obj:`array-like` or :obj:`float`): mapped values
+
+        Returns:
+          values (:obj:`array-like` or :obj:`float`): the values in
+          units of `angle_unit`, if `key` is a spatial angle
+        """
+        if (key not in spatial_angles) or (key in getattr(self, 'map_lims', {})):
+            return values
+
+        amax = angle_unit_maxs[getattr(self, 'angle_unit', None) or 'cycles']
+
+        if key in z_angles:
+            # polar angles are folded onto half a turn
+            amax *= 0.5
+
+        return np.asarray(values) * amax
+
     def validate_mapping(self):
         """ Validate the mapping choices, warn and/or except on issues.
 

--- a/src/strauss/sources.py
+++ b/src/strauss/sources.py
@@ -133,6 +133,9 @@ class Source:
         :meth:`apply_mapping_functions`.
       names (:obj:`list(str)`): name of each source, used to look up
         its table. Defaults to `source_0` to `source_N`.
+      table_angle_unit (:obj:`str`): units to report spatial angles
+        in, rather than as the mapped fractions the sonification works
+        in. Defaults to degrees where unset.
       origin (:obj:`dict`): keys are `mapped_quantities`, entries say
         where each mapping came from - `'mapped'` where requested
         directly, or `'auto'` or `'fixed'` where a higher-level
@@ -163,6 +166,9 @@ class Source:
 
         # names are generated from n_sources on demand, until set
         self._names = None
+
+        # units to report spatial angles in, degrees unless asked otherwise
+        self.table_angle_unit = None
 
         # everything asked for here is user-specified by definition, higher
         # level interfaces overwrite this where they add parameters themselves
@@ -232,13 +238,19 @@ class Source:
         return names.index(source)
 
     def in_angle_unit(self, key, values):
-        """Express mapped values of a spatial angle in its input unit.
+        """Express mapped values of a spatial angle in reporting units.
 
         Spatial angles are mapped to a fraction of the angular range
         they span, as this is what the sonification works in. This
-        converts such values back to the unit they were given in (see
-        the `angle_unit` argument of :meth:`apply_mapping_functions`),
-        leaving any other parameter alone.
+        converts such values to `table_angle_unit`, leaving any other
+        parameter alone. Where no unit was asked for, angles are
+        reported in degrees as the most readable choice, whatever units
+        they were given in.
+
+        Note:
+          Angles given `map_lims` are mapped linearly rather than
+          wrapped, so are not angular quantities to convert, and are
+          left alone too.
 
         Args:
           key (:obj:`str`): name of the mapped parameter
@@ -246,12 +258,12 @@ class Source:
 
         Returns:
           values (:obj:`array-like` or :obj:`float`): the values in
-          units of `angle_unit`, if `key` is a spatial angle
+          units of `table_angle_unit`, if `key` is a spatial angle
         """
         if (key not in spatial_angles) or (key in getattr(self, 'map_lims', {})):
             return values
 
-        amax = angle_unit_maxs[getattr(self, 'angle_unit', None) or 'cycles']
+        amax = angle_unit_maxs[getattr(self, 'table_angle_unit', None) or 'degrees']
 
         if key in z_angles:
             # polar angles are folded onto half a turn

--- a/src/strauss/sources.py
+++ b/src/strauss/sources.py
@@ -12,8 +12,10 @@ Attributes:
    param_limits (:obj:`list(tuple)`): List of tuples indicating the default
 	numerical ranges bounding corresponding mappable parameter
 	(e.g. 0-1 for volume).
-   param_lim_dict (:obj:`dict`): Dictionary combining `mappable` (keys) and 
+   param_lim_dict (:obj:`dict`): Dictionary combining `mappable` (keys) and
 	`param_limits` (items).
+   nan_modes (:obj:`tuple(str)`): Supported values of the `handle_nans`
+	keyword, controlling what becomes of non-finite input data.
 
 Todo:
     * Store mappable, evolvable and parameter ranges in YAML files (cleaner). 
@@ -25,7 +27,7 @@ import pandas as pd
 from scipy.interpolate import interp1d
 import matplotlib.pyplot as plt
 from scipy import signal as sig
-from .utilities import rescale_values, amplitude_to_db
+from .utilities import rescale_values, amplitude_to_db, nan_mute_envelope
 from .stream import filter_freq_lims
 import warnings
 import copy
@@ -211,6 +213,83 @@ invalid_combos = {('azimuth', 'pan') : 'angle_pan',
 invalid_explanations = {'angle_pan': "'pan' and spatial angles are both controlling spatialisation",
                         'alias': "these represent different names for the same quantity"}
 
+# how non-finite input data is handled. 'interpolate' fills the gaps and
+# sounds the result, 'silent' fills them and then mutes the audio they
+# would have made, so a gap in the data is heard as a gap in the sound
+nan_modes = ('silent', 'interpolate')
+
+# parameters whose missing values are set to 0 rather than applying silence
+# envelope
+nan_zero_filled = ('spectrum',)
+
+def _any_nonfinite(values):
+    """Test for any non-finite entry, however the values are nested.
+
+    Args:
+      values: array, scalar, or (possibly ragged) list of either
+
+    Returns:
+      any_bad (:obj:`bool`): True if any entry is non-finite
+    """
+    # lists are checked entry by entry, as they may be ragged and so
+    # cannot be made into an array to test in one go
+    if isinstance(values, (list, tuple)):
+        return any(_any_nonfinite(v) for v in values)
+    return bool((~np.isfinite(np.asarray(values, dtype=float))).any())
+
+def _replace_nonfinite(values, fill):
+    """Substitute non-finite values with a specified value.
+
+    Args:
+      values: array, scalar, or list of either
+      fill (:obj:`float`): value to substitute
+
+    Returns:
+      filled: as `values`, with non-finite entries replaced
+    """
+    if isinstance(values, (list, tuple)):
+        return [_replace_nonfinite(v, fill) for v in values]
+    values = np.asarray(values, dtype=float)
+    if values.ndim == 0:
+        return float(values) if np.isfinite(values) else float(fill)
+    # arrays keep their shape, so that a spectrum stays a value per frequency
+    # per time rather than being taken apart into rows
+    filled = values.copy()
+    filled[(~np.isfinite(np.asarray(filled, dtype=float)))] = fill
+    return filled
+
+def _interp_fill(values, mask, x=None):
+    """Fill the masked entries of an array by linear interpolation.
+
+    Interpolates along `x`, or along the entry positions where no axis
+    is given, taking the unmasked entries as the points to interpolate
+    between. A masked run at either end has nothing to interpolate
+    between and clamps to the nearest unmasked value.
+
+    Args:
+      values (:obj:`ndarray`): values to fill
+      mask (:obj:`ndarray`): boolean, True where a value needs filling
+      x (`optional`, :obj:`ndarray`): axis to interpolate along, which
+        must itself be finite
+
+    Returns:
+      filled (:obj:`ndarray`): copy of `values` with masked entries
+        filled, or unchanged where nothing is left to interpolate from
+    """
+    filled = np.array(values, dtype=float)
+    good = ~mask
+    if (not mask.any()) or (not good.any()):
+        return filled
+    if x is None:
+        x = np.arange(filled.size, dtype=float)
+    x = np.asarray(x, dtype=float)
+
+    # np.interp needs the points it interpolates between in ascending
+    # order, which event times in particular are not guaranteed to be
+    order = np.argsort(x[good])
+    filled[mask] = np.interp(x[mask], x[good][order], filled[good][order])
+    return filled
+
 class Source:
     """ Generic source class defining common methods/attributes
     
@@ -242,29 +321,51 @@ class Source:
         where each mapping came from - `'mapped'` where requested
         directly, or `'auto'` or `'fixed'` where a higher-level
         interface (e.g. `AudioFigure`) added it.
+      handle_nans (:obj:`str`): what becomes of non-finite input data,
+        either `'silent'` or `'interpolate'`. See :meth:`__init__`.
+      nan_mask (:obj:`ndarray` or :obj:`list(ndarray)`): boolean, True
+        where any mapped quantity was non-finite and its value has been
+        interpolated. Set by :meth:`apply_mapping_functions`.
 
     Raises:
     	UnrecognisedProperty: if `mapped_quantities` entry not in `mappable`.
+    	ValueError: if `handle_nans` is not a recognised mode.
     """
-    def __init__(self, mapped_quantities):
+    def __init__(self, mapped_quantities, handle_nans='silent'):
         """
         Args:
     	  mapped_quantities (:obj:`list(str)`): The subset of parameters to
     	    which data will be mapped.
+    	  handle_nans (`optional`, :obj:`str`): how non-finite (`NaN` or
+    	    `±inf`) input data is handled. Both modes linearly interpolate
+    	    the missing values in time, so that they don't propagate
+    	    through the mapping; `'interpolate'` then sounds the
+    	    interpolated data as it is, while `'silent'` (the default)
+    	    additionally mutes the audio the missing data would have made,
+    	    so that a gap in the data is heard as a gap in the sound.
         """
-        
+
         # check these are all mappable parameters
-        
+
         for q in mapped_quantities:
             if q not in mappable:
                 raise UnrecognisedProperty(
                     f"Property \"{q}\" is not recognised")
-            
+
+        if handle_nans not in nan_modes:
+            raise ValueError(f"handle_nans mode \"{handle_nans}\" is not "
+                             f"recognised, choose from: {list(nan_modes)}")
+
         # initialise common structures
         self.mapped_quantities = mapped_quantities
         self.raw_mapping = {}
         self.mapping = {}
         self.mapped_samples = {}
+
+        # non-finite value handling, with the mask filled in once the data
+        # has been read in and the mapping functions applied
+        self.handle_nans = handle_nans
+        self.nan_mask = None
 
         # names are generated from n_sources on demand, until set
         self._names = None
@@ -423,7 +524,177 @@ class Source:
                 err_text += e
                 errnum += 1
             raise Exception(f"Found {len(errs)} critical issues with mapping:\n\n", err_text)
-        
+
+    def _keep_sources(self, keep):
+        """Thin the sources down to those flagged, names and all.
+
+        Args:
+          keep (:obj:`ndarray`): boolean, True for each source to keep
+        """
+        keep = np.asarray(keep, dtype=bool)
+
+        for key in self.raw_mapping:
+            vals = self.raw_mapping[key]
+            if isinstance(vals, np.ndarray):
+                self.raw_mapping[key] = vals[keep]
+            else:
+                self.raw_mapping[key] = [v for v, k in zip(vals, keep) if k]
+
+        # names identify the sources, so they thin along with the data they
+        # name, as they do for the events thinned by 'max_notes_per_sec'
+        if self._names is not None:
+            self._names = [n for n, k in zip(self._names, keep) if k]
+
+        self.n_sources = int(keep.sum())
+
+    def _map_values(self, key):
+        """Apply the mapping function to a key, and find its input limits.
+
+        Args:
+          key (:obj:`str`): the mapped quantity to convert
+
+        Returns:
+          mapvals: the converted input data
+          vallims (:obj:`tuple`): limits to descale the data by, as
+            absolute values or percentile strings
+        """
+        rawvals = self.raw_mapping[key]
+
+        # apply mapping functions if specified
+        if key in self.map_funcs:
+            func = self.map_funcs[key]
+            func_list = [func] if callable(func) else func
+            mapvals = rawvals
+            for f in func_list: # Allow multiple functions to be applied in order given
+                mapvals = f(mapvals)
+        else:
+            mapvals = rawvals
+
+        # set mapping limits if specified
+        if key in self.map_lims:
+            vallims = self.map_lims[key]
+        elif key in spatial_angles:
+            # special case for spatial angles - use absolute values
+            # set domain based on units unit (by default in cycles)
+            amax = 1
+            if self.angle_unit:
+                amax = angle_unit_maxs[self.angle_unit]
+            # for angles make sure conforms to units
+            if key in z_angles:
+                # triangle wave behaviour to map polar angle domain
+                mapvals = (sig.sawtooth(2*np.pi*(np.array(mapvals)/amax),0.5) + 1)/2
+            else:
+                # sawtooth wave behaviour to map azimuthal angle domain
+                mapvals = (np.array(mapvals)%amax)/amax
+            vallims = (0, 1)
+        else:
+            vallims = ('0%','100%')
+
+        return mapvals, vallims
+
+    def _drop_nonfinite_times(self):
+        """Discard input data with no finite time to place it at.
+
+        A non-finite time says neither when a source sounds nor what to
+        interpolate its other values against, so it is dropped in both
+        `handle_nans` modes rather than filled.
+        """
+        if 'time' not in self.raw_mapping:
+            return
+
+        bad = ~np.isfinite(np.asarray(self.raw_mapping['time'], dtype=float))
+        if not bad.any():
+            return
+
+        warnings.warn(f"Dropping {bad.sum()} of {self.n_sources} sources with "
+                      "a non-finite 'time', as there is no point in the "
+                      "sonification to place them at.", stacklevel=3)
+        self._keep_sources(~bad)
+
+    def _init_nan_mask(self):
+        """Set up an empty non-finite value mask, one entry per source."""
+        self.nan_mask = np.zeros(self.n_sources, dtype=bool)
+
+    def _update_nan_mask(self, mapvals):
+        """Fold one mapped quantity into the non-finite value mask.
+
+        The mask is the union over every mapped quantity, so a source
+        counts as missing if any one of the parameters it sounds with
+        has no value.
+
+        Args:
+          mapvals: converted input data for one mapped quantity
+        """
+        self.nan_mask |= ~np.isfinite(np.asarray(mapvals, dtype=float))
+
+    def _fill_nan(self, key, mapvals):
+        """Interpolate over the non-finite values of one mapped quantity.
+
+        Args:
+          key (:obj:`str`): the mapped quantity being filled
+          mapvals: its converted input data
+
+        Returns:
+          filled: `mapvals` with its non-finite entries interpolated
+        """
+        mask = ~np.isfinite(np.asarray(mapvals, dtype=float))
+        if not mask.any():
+            return mapvals
+
+        # sources are interpolated against the time they sound at, so that
+        # a gap is filled from the values either side of it in the audio
+        return _interp_fill(mapvals, mask, self.raw_mapping.get('time', None))
+
+    def _nan_keep_mask(self):
+        """Which sources survive `'silent'` mode, or None to keep them all.
+
+        Returns:
+          keep (:obj:`ndarray` or :obj:`None`): boolean, True for each
+            source to keep
+        """
+        return None
+
+    def _warn_fully_missing(self):
+        """Warn about sources with no data anywhere in their lifetime.
+
+        Events missing anything are either skipped or interpolated from
+        their neighbours, both of which are already reported, so there
+        is nothing further to say here - see
+        :meth:`Objects._warn_fully_missing`.
+        """
+        return
+
+    def all_missing(self, index):
+        """Whether a source has no data to sound at all.
+
+        Args:
+          index (:obj:`int`): index of the source
+
+        Returns:
+          missing (:obj:`bool`): True if every value is interpolated
+        """
+        if self.nan_mask is None:
+            return False
+        return bool(np.all(self.nan_mask[index]))
+
+    def mute_envelope(self, index, ramp):
+        """Gain curve muting the intervals where a source has no data.
+
+        Events are discrete in time, with no interval within one to
+        mute, so nothing is returned here - see
+        :meth:`Objects.mute_envelope`.
+
+        Args:
+          index (:obj:`int`): index of the source
+          ramp (:obj:`float`): duration of the ramps into and out of a
+            mute, as a fraction of the source's lifetime
+
+        Returns:
+          knots (:obj:`tuple(ndarray)` or :obj:`None`): the `x` and `y`
+            of the curve, or None where there is nothing to mute
+        """
+        return None
+
     def apply_mapping_functions(self, map_funcs={}, map_lims={}, param_lims={}, angle_unit=None):
         """ Taking input data and mapping to parameters.
 
@@ -468,7 +739,14 @@ class Source:
            There is special behaviour for the `polar` and `azimuth`
            parameters, to ensure shortest angular distance when
            interpolating across the 0-2pi and 0-pi boundaries.
-                   
+
+        Note:
+           Non-finite input values are recorded in :attr:`nan_mask` and
+           then interpolated over, so that they neither reach the
+           generator nor set the limits any other source is descaled
+           by. See the `handle_nans` argument of :meth:`__init__` for
+           what is then done with the audio they would have made.
+
         """
 
         # first store the chosen mapping variables
@@ -479,59 +757,88 @@ class Source:
         
         # then validate the mapping combinations
         self.validate_mapping()
-        
+
+        # a non-finite time says neither when a source sounds nor what to
+        # interpolate against, so those go before anything reads the time axis
+        self._drop_nonfinite_times()
+
         # set up dictionaries to store the limits
         self.lims = {}
         self.plims = {}
-        
+
+        # convert every parameter and find where the data is missing before
+        # rescaling any of them. Doing this up front matters twice over: the
+        # mapping functions make non-finite values of their own (the log of a
+        # non-positive value, say), and 'silent' sources are dropped below,
+        # which changes the data the limits are then taken over
+        mapped = {}
+        vallims = {}
+        self._init_nan_mask()
+
         for key in self.mapped_quantities:
-            rawvals = self.raw_mapping[key]
+            mapped[key], vallims[key] = self._map_values(key)
+            if key not in nan_zero_filled:
+                self._update_nan_mask(mapped[key])
 
-            # apply mapping functions if specified
-            if key in map_funcs:
-                func = map_funcs[key]
-                func_list = [func] if callable(func) else func
-                mapvals = rawvals
-                for f in func_list: # Allow multiple functions to be applied in order given
-                    mapvals = f(mapvals)
-                
-            else:
-                mapvals = rawvals
+        # in 'silent' mode an event with missing data is not sounded at all,
+        # so drop it rather than synthesise
+        keep = self._nan_keep_mask()
+        if keep is not None:
+            for key in mapped:
+                mapped[key] = np.asarray(mapped[key])[keep]
+            self.nan_mask = self.nan_mask[keep]
+            self._keep_sources(keep)
 
-            # set mapping limits if specified
-            if key in map_lims:
-                vallims = map_lims[key]
-            elif key in spatial_angles:
-                # special case for spatial angles - use absolute values
-                # set domain based on units unit (by default in cycles)
-                amax = 1
-                if self.angle_unit:
-                    amax = angle_unit_maxs[self.angle_unit]
-                # for angles make sure conforms to units
-                if key in z_angles:
-                    # triangle wave behaviour to map polar angle domain
-                    mapvals = (sig.sawtooth(2*np.pi*(np.array(mapvals)/amax),0.5) + 1)/2
-                else:
-                    # sawtooth wave behaviour to map azimuthal angle domain
-                    mapvals = (np.array(mapvals)%amax)/amax
-                vallims = (0, 1)
-            else:
-                vallims = ('0%','100%')
-                
+        if not self.n_sources:
+            warnings.warn("No sources are left with data to sound - the "
+                          "sonification will be silent.", stacklevel=2)
+            return
+
+        self._warn_fully_missing()
+
+        for key in self.mapped_quantities:
+            mapvals = mapped[key]
+
             # set parameter limits if specified
             if key in param_lims:
                 plims = param_lims[key]
             else:
                 plims = param_lim_dict[key]
 
-            # set the limits in input units
-            lims = set_limits(vallims, mapvals, warn=True)
+            # set the limits in input units. Non-finite values are excluded,
+            # so that one missing value cannot set the range for every source
+            lims = set_limits(vallims[key], mapvals, warn=True)
+
+            # then fill the gaps, so that they propagate no further than the
+            # limits they have just been left out of
+            if key in nan_zero_filled:
+                # a missing spectral bin is an absence of power at that
+                # frequency rather than a gap to interpolate across, so it
+                # goes to the bottom of the input range - which descales to
+                # the bottom of the parameter range, i.e. silence
+                mapvals = _replace_nonfinite(mapvals, lims[0])
+            else:
+                mapvals = self._fill_nan(key, mapvals)
+
+            # a parameter with no finite values anywhere has neither limits to
+            # descale by nor anything to interpolate from. Warn and put it in
+            # the middle of its range, rather than raising and taking the rest
+            # of the sonification down with it
+            if not np.all(np.isfinite(lims)):
+                lims = (0., 1.)
+            if _any_nonfinite(mapvals):
+                warnings.warn(f"Mapped quantity '{key}' has no finite values "
+                              "to interpolate from, so it is mapped to the "
+                              f"middle of its {tuple(plims)} range. Sources "
+                              "missing every value are silent in 'silent' "
+                              "mode.", stacklevel=2)
+                mapvals = _replace_nonfinite(mapvals, 0.5*(lims[0] + lims[1]))
 
             # lets store the limits from input for later conversion
             self.lims[key] = lims
             self.plims[key] = plims
-            
-            # limit mapped values from 0 to 1 NOTE: do we want to mix and match const and evo?            
+
+            # limit mapped values from 0 to 1 NOTE: do we want to mix and match const and evo?
             if hasattr(mapvals[0], "__iter__"):
                 self.mapping[key] = []
                 for i in range(self.n_sources):
@@ -607,9 +914,30 @@ class Events(Source):
             if key in datadict:
                 self.raw_mapping[key] = datadict[key]
             else:
-                Exception(f"Mapped property {key} not in datadict.")
-        self.n_sources = np.array(datadict[key]).shape[0]
- 
+                raise KeyError(f"Mapped property {key} not in datadict.")
+        self.n_sources = len(self.raw_mapping[self.mapped_quantities[0]])
+
+    def _nan_keep_mask(self):
+        """Which events survive `'silent'` mode, or None to keep them all.
+
+        An event is a single point in time, so there is no gap within it
+        to mute - it either sounds or it does not. Events missing any
+        mapped value are therefore dropped outright, rather than
+        synthesised and then silenced.
+
+        Returns:
+          keep (:obj:`ndarray` or :obj:`None`): boolean, True for each
+            event to keep
+        """
+        if (self.handle_nans != 'silent') or (not self.nan_mask.any()):
+            return None
+
+        warnings.warn(f"Skipping {self.nan_mask.sum()} of {self.n_sources} "
+                      "events with non-finite values, as handle_nans is "
+                      "'silent'. Use handle_nans='interpolate' to sound them "
+                      "at interpolated values instead.", stacklevel=3)
+        return ~self.nan_mask
+
 class Objects(Source):
     """ Represent data as time-continuous objects.
     
@@ -641,10 +969,182 @@ class Objects(Source):
                 else:
                     self.raw_mapping[key] = d
             else:
-                Exception(f"Mapped property {key} not in datadict.")
-        self.n_sources = np.array(self.raw_mapping[key]).shape[0]
+                raise KeyError(f"Mapped property {key} not in datadict.")
+        self.n_sources = len(self.raw_mapping[self.mapped_quantities[0]])
+
+    def _sample_counts(self):
+        """Number of time samples of each object, 1 where non-evolving."""
+        if 'time_evo' in self.raw_mapping:
+            return [np.size(t) for t in self.raw_mapping['time_evo']]
+        return [1] * self.n_sources
+
+    def _drop_nonfinite_times(self):
+        """Discard samples of each object with no finite time to place them.
+
+        A non-finite `time_evo` sample gives the values alongside it no
+        position to be interpolated at, so the whole sample is dropped
+        from every array of that object. An object whose times are
+        entirely non-finite has no time axis at all, and is dropped.
+        """
+        if 'time_evo' not in self.raw_mapping:
+            return
+        if not _any_nonfinite(self.raw_mapping['time_evo']):
+            return
+
+        # the arrays are sliced per source, so they cannot stay as the rows
+        # of a single 2D array once objects lose different samples
+        self.raw_mapping = {k: list(v) for k, v in self.raw_mapping.items()}
+
+        keep = np.ones(self.n_sources, dtype=bool)
+        ndropped = 0
+
+        for i in range(self.n_sources):
+            times = np.atleast_1d(np.asarray(self.raw_mapping['time_evo'][i],
+                                             dtype=float))
+            bad = ~np.isfinite(np.asarray(times, dtype=float))
+            if not bad.any():
+                continue
+            if bad.all():
+                keep[i] = False
+                continue
+
+            ndropped += int(bad.sum())
+            for key in self.mapped_quantities:
+                vals = np.asarray(self.raw_mapping[key][i])
+                # constants have no samples of their own to drop. Anything
+                # else is indexed by time along its first axis, a spectrum
+                # carrying a whole row of frequencies per entry
+                if vals.ndim and (vals.shape[0] == times.size):
+                    self.raw_mapping[key][i] = vals[~bad]
+
+        if ndropped:
+            warnings.warn(f"Dropping {ndropped} time samples with a non-finite "
+                          "'time_evo', as there is no point in the "
+                          "sonification to place them at.", stacklevel=3)
+        if not keep.all():
+            warnings.warn(f"Dropping {(~keep).sum()} of {self.n_sources} "
+                          "objects whose 'time_evo' is entirely non-finite.",
+                          stacklevel=3)
+            self._keep_sources(keep)
+
+    def _init_nan_mask(self):
+        """Set up an empty mask per object, one entry per time sample."""
+        self.nan_mask = [np.zeros(n, dtype=bool) for n in self._sample_counts()]
+
+    def _update_nan_mask(self, mapvals):
+        """Fold one mapped quantity into the non-finite value mask.
+
+        Args:
+          mapvals: converted input data for one mapped quantity
+        """
+        for i in range(self.n_sources):
+            # a non-finite constant holds for the whole object's lifetime,
+            # and broadcasts over every sample of its mask accordingly
+            self.nan_mask[i] |= np.atleast_1d(~np.isfinite(np.asarray(mapvals[i], dtype=float)))
+
+    def _fill_nan(self, key, mapvals):
+        """Interpolate over the non-finite values of one mapped quantity.
+
+        Evolving values are interpolated in time within their own
+        object. A constant has no time axis to interpolate along, so it
+        falls back to the median of the finite values the other objects
+        give this parameter.
+
+        Args:
+          key (:obj:`str`): the mapped quantity being filled
+          mapvals: its converted input data
+
+        Returns:
+          filled (:obj:`list`): `mapvals` with non-finite entries filled
+        """
+        if not _any_nonfinite(mapvals):
+            return mapvals
+
+        allvals = np.concatenate([np.atleast_1d(np.asarray(v, dtype=float)).ravel()
+                                  for v in mapvals])
+        finite = allvals[np.isfinite(allvals)]
+        fallback = np.median(finite) if finite.size else np.nan
+
+        filled = list(mapvals)
+        for i in range(self.n_sources):
+            vals = np.atleast_1d(np.asarray(mapvals[i], dtype=float))
+            bad = ~np.isfinite(np.asarray(vals, dtype=float))
+            if not bad.any():
+                continue
+            if vals.size == 1:
+                filled[i] = fallback
+            else:
+                times = None
+                if 'time_evo' in self.raw_mapping:
+                    times = self.raw_mapping['time_evo'][i]
+                filled[i] = _interp_fill(vals, bad, times)
+
+        return filled
+
+    def _warn_fully_missing(self):
+        """Warn about objects with no data anywhere in their lifetime.
+
+        Such an object sounds nothing at all in `'silent'` mode, and
+        sounds throughout at values interpolated from elsewhere in
+        `'interpolate'` mode. Either is worth saying out loud, as
+        neither represents data the object itself gave.
+        """
+        missing = [i for i in range(self.n_sources) if np.all(self.nan_mask[i])]
+        if not missing:
+            return
+
+        named = ', '.join(str(self.names[i]) for i in missing[:5])
+        if len(missing) > 5:
+            named += f', ... ({len(missing)} in total)'
+
+        if self.handle_nans == 'silent':
+            fate = "will be silent throughout"
+        else:
+            fate = ("will sound throughout at values interpolated from "
+                    "elsewhere, rather than any of their own")
+
+        warnings.warn(f"Objects with no finite data at any point in their "
+                      f"lifetime ({named}) {fate}.", stacklevel=3)
+
+    def mute_envelope(self, index, ramp):
+        """Gain curve muting the intervals where an object has no data.
+
+        Built over the object's mapped `time_evo`, the same axis its
+        evolving parameters are interpolated against, so that the curve
+        can be read at the sample fractions of the note in the same way
+        they are.
+
+        Args:
+          index (:obj:`int`): index of the object
+          ramp (:obj:`float`): duration of the ramps into and out of a
+            mute, as a fraction of the object's lifetime
+
+        Returns:
+          knots (:obj:`tuple(ndarray)` or :obj:`None`): the `x` and `y`
+            of the curve, or None where there is nothing to mute
+        """
+        if self.nan_mask is None:
+            return None
+
+        mask = np.atleast_1d(self.nan_mask[index])
+        if 'time_evo' in self.mapping:
+            times = np.atleast_1d(np.asarray(self.mapping['time_evo'][index],
+                                             dtype=float))
+        else:
+            # without a time evolution an object holds one value throughout,
+            # so its lifetime is either wholly muted or not muted at all
+            times = np.linspace(0., 1., mask.size)
+
+        return nan_mute_envelope(mask, times, ramp)
 
 def set_limits(vallims, mapvals, warn=True):
+    # non-finite values have no place in the range of the data. Taken
+    # through np.percentile a single one of them would return NaN, setting
+    # the limits every source is then descaled by
+    flat = np.hstack([mapvals]).astype(float)
+    flat = np.where(np.isfinite(flat), flat, np.nan)
+    nothing_finite = not np.isfinite(flat).any()
+
     lims = []
     for l in vallims:
         if isinstance(l, str):
@@ -659,11 +1159,16 @@ def set_limits(vallims, mapvals, warn=True):
             buff = 1
             sub = 0
             if pc > 100:
-                # if percentile over 100 we add 
+                # if percentile over 100 we add
                 buff = pc/100.
                 pc = 100
                 sub = lims[0]
-            lim = sub + (np.percentile(np.hstack([mapvals]), pc) - sub)*buff
+            if nothing_finite:
+                # no data to take a percentile over - the caller warns and
+                # falls back to the middle of the parameter range
+                lims.append(np.nan)
+                continue
+            lim = sub + (np.nanpercentile(flat, pc) - sub)*buff
             lims.append(lim)
         else:
             # numerical values notate absolute limits

--- a/src/strauss/sources.py
+++ b/src/strauss/sources.py
@@ -25,7 +25,8 @@ import pandas as pd
 from scipy.interpolate import interp1d
 import matplotlib.pyplot as plt
 from scipy import signal as sig
-from .utilities import rescale_values
+from .utilities import rescale_values, amplitude_to_db
+from .stream import filter_freq_lims
 import warnings
 import copy
 
@@ -90,6 +91,107 @@ param_limits = [(0,1),#np.pi),
                 (0,2)]     
 
 param_lim_dict = dict(zip(mappable, param_limits))
+
+
+# readable names for the mapped parameters, for tables and other output.
+param_names = {'polar': 'Polar Angle',
+               'azimuth': 'Azimuthal Angle',
+               'theta': 'Polar Angle',
+               'phi': 'Azimuthal Angle',
+               'volume': 'Volume',
+               'pitch': 'Pitch',
+               'time': 'Time',
+               'cutoff': 'Cutoff Frequency',
+               'time_evo': 'Time',
+               'spectrum': 'Spectrum',
+               'pitch_shift': 'Pitch Shift',
+               'pan': 'Stereo Pan',
+               'volume_envelope/A': 'Volume Attack',
+               'volume_envelope/D': 'Volume Decay',
+               'volume_envelope/S': 'Volume Sustain',
+               'volume_envelope/R': 'Volume Release',
+               'volume_lfo/freq': 'Volume LFO Frequency',
+               'volume_lfo/freq_shift': 'Volume LFO Frequency Shift',
+               'volume_lfo/amount': 'Volume LFO Amount',
+               'pitch_lfo/freq': 'Pitch LFO Frequency',
+               'pitch_lfo/freq_shift': 'Pitch LFO Frequency Shift',
+               'pitch_lfo/amount': 'Pitch LFO Amount',
+               # not mapped parameters, but reported alongside them
+               'note': 'Note',
+               'source': 'Source',
+               'note_length': 'Note Length'}
+
+
+# conversions from a mapped value to the quantity it is worth reporting,
+def _cutoff_to_freq(values):
+    """Convert a mapped filter cutoff to the frequency it cuts at.
+
+    The cutoff is mapped logarithmically between the frequency limits
+    of the sweep applied in :meth:`strauss.stream.Stream.filt_sweep`.
+
+    Args:
+      values (:obj:`array-like` or :obj:`float`): mapped cutoff values
+
+    Returns:
+      freqs (:obj:`array-like` or :obj:`float`): cutoff frequencies in Hz
+    """
+    lolim, hilim = np.log10(filter_freq_lims)
+
+    return pow(10., np.asarray(values, dtype=float)*(hilim-lolim) + lolim)
+
+
+# below this, a sound is silent rather than quiet - well under the
+# dynamic range of 16-bit audio
+quiet_db = -100.
+
+def _amplitude_to_db(values):
+    """Convert a mapped amplitude to decibels.
+
+    Amplitudes are mapped as a fraction of the loudest the parameter
+    goes, which is 0 dB.
+
+    Note:
+      Nothing below `quiet_db` is audible, so everything quieter is
+      reported as minus infinity decibels rather than as a number that
+      suggests a distinction nobody can hear.
+
+    Args:
+      values (:obj:`array-like` or :obj:`float`): mapped amplitudes
+
+    Returns:
+      db (:obj:`array-like` or :obj:`float`): the amplitudes in decibels
+    """
+    db = amplitude_to_db(values)
+
+    return np.where(db < quiet_db, -np.inf, db)
+
+
+param_converters = {
+    # panning is the fraction of the amplitude from the right speaker
+    'pan': (lambda values: 100*np.asarray(values), '% right'),
+    # loudness is heard logarithmically, so is reported that way
+    'volume': (_amplitude_to_db, 'dB'),
+    # a cutoff is a fraction of a logarithmic sweep, not a frequency
+    'cutoff': (_cutoff_to_freq, 'Hz'),
+    'time': (lambda values: np.asarray(values, dtype=float), 'seconds'),
+    'time_evo': (lambda values: np.asarray(values, dtype=float), 'seconds'),
+}
+
+
+def display_name(key):
+    """A readable name for a mapped parameter.
+
+    Args:
+      key (:obj:`str`): name of the parameter
+
+    Returns:
+      name (:obj:`str`): its readable name, from `param_names`, or the
+      parameter name tidied up where it has no entry there
+    """
+    if key in param_names:
+        return param_names[key]
+
+    return key.replace('/', ' ').replace('_', ' ').title()
 
 
 spatial_angles = ('azimuth', 'polar', 'theta', 'phi')

--- a/src/strauss/sources.py
+++ b/src/strauss/sources.py
@@ -1138,10 +1138,18 @@ class Objects(Source):
         return nan_mute_envelope(mask, times, ramp)
 
 def set_limits(vallims, mapvals, warn=True):
+    # sources need not share a length - and do not, once samples with no
+    # finite time have been dropped from some of them - so flatten source by
+    # source rather than stacking, which cannot handle a ragged set
+    if isinstance(mapvals, (list, tuple)):
+        flat = np.concatenate([np.asarray(v, dtype=float).ravel()
+                               for v in mapvals])
+    else:
+        flat = np.asarray(mapvals, dtype=float).ravel()
+
     # non-finite values have no place in the range of the data. Taken
     # through np.percentile a single one of them would return NaN, setting
     # the limits every source is then descaled by
-    flat = np.hstack([mapvals]).astype(float)
     flat = np.where(np.isfinite(flat), flat, np.nan)
     nothing_finite = not np.isfinite(flat).any()
 

--- a/src/strauss/sources.py
+++ b/src/strauss/sources.py
@@ -130,6 +130,8 @@ class Source:
         mapped values of evolving parameters rather than replacing
         them with interpolation functions. Set by
         :meth:`apply_mapping_functions`.
+      names (:obj:`list(str)`): name of each source, used to look up
+        its table. Defaults to `source_0` to `source_N`.
       origin (:obj:`dict`): keys are `mapped_quantities`, entries say
         where each mapping came from - `'mapped'` where requested
         directly, or `'auto'` or `'fixed'` where a higher-level
@@ -158,9 +160,75 @@ class Source:
         self.mapping = {}
         self.mapped_samples = {}
 
+        # names are generated from n_sources on demand, until set
+        self._names = None
+
         # everything asked for here is user-specified by definition, higher
         # level interfaces overwrite this where they add parameters themselves
         self.origin = {q: 'mapped' for q in mapped_quantities}
+
+    @property
+    def names(self):
+        """:obj:`list(str)`: name of each source.
+
+        Names identify sources when looking up their tables. Where none
+        are set, sources are named `source_0` to `source_N` in the order
+        they were provided. Setting requires the data to have been read
+        in already, as the number of sources follows from it.
+
+        Raises:
+          Exception: if set before any data is read in.
+          ValueError: if the number of names does not match the number
+            of sources, or if any name repeats.
+        """
+        if self._names is not None:
+            return self._names
+        return [f'source_{i}' for i in range(getattr(self, 'n_sources', 0))]
+
+    @names.setter
+    def names(self, names):
+        if not hasattr(self, 'n_sources'):
+            raise Exception("Cannot name sources before reading in data - "
+                            "use 'fromdict' or 'fromfile' first.")
+
+        names = [str(n) for n in names]
+
+        if len(names) != self.n_sources:
+            raise ValueError(f"Got {len(names)} source names for "
+                             f"{self.n_sources} sources.")
+
+        if len(set(names)) != len(names):
+            repeats = sorted({n for n in names if names.count(n) > 1})
+            raise ValueError("Source names must be unique, but multiple"
+                             f"insatances of {repeats} found.")
+
+        self._names = names
+
+    def source_index(self, source):
+        """Resolve a source to its index.
+
+        Args:
+          source (:obj:`str` or :obj:`int`): name of the source, as in
+            :attr:`names`, or its index.
+
+        Returns:
+          index (:obj:`int`): index of the source
+
+        Raises:
+          KeyError: if no source goes by that name.
+          IndexError: if the index falls outside the sources.
+        """
+        if isinstance(source, (int, np.integer)):
+            if not -self.n_sources <= source < self.n_sources:
+                raise IndexError(f"Source index {source} is outside the "
+                                 f"{self.n_sources} sources.")
+            return int(source) % self.n_sources
+
+        names = self.names
+        if source not in names:
+            raise KeyError(f"No source named '{source}'. Choose from: {names}")
+
+        return names.index(source)
 
     def validate_mapping(self):
         """ Validate the mapping choices, warn and/or except on issues.

--- a/src/strauss/sources.py
+++ b/src/strauss/sources.py
@@ -25,8 +25,9 @@ import pandas as pd
 from scipy.interpolate import interp1d
 import matplotlib.pyplot as plt
 from scipy import signal as sig
-from .utilities import rescale_values 
+from .utilities import rescale_values
 import warnings
+import copy
 
 mappable = ['polar',
             'azimuth',
@@ -125,7 +126,15 @@ class Source:
       mapping (:obj:`dict`): processed mapping :obj:`dict` rescaled
         to parameter ranges, or interpolation funtions for evolving
         parameters.
-    
+      mapped_samples (:obj:`dict`): as `mapping`, but retaining the
+        mapped values of evolving parameters rather than replacing
+        them with interpolation functions. Set by
+        :meth:`apply_mapping_functions`.
+      origin (:obj:`dict`): keys are `mapped_quantities`, entries say
+        where each mapping came from - `'mapped'` where requested
+        directly, or `'auto'` or `'fixed'` where a higher-level
+        interface (e.g. `AudioFigure`) added it.
+
     Raises:
     	UnrecognisedProperty: if `mapped_quantities` entry not in `mappable`.
     """
@@ -147,6 +156,11 @@ class Source:
         self.mapped_quantities = mapped_quantities
         self.raw_mapping = {}
         self.mapping = {}
+        self.mapped_samples = {}
+
+        # everything asked for here is user-specified by definition, higher
+        # level interfaces overwrite this where they add parameters themselves
+        self.origin = {q: 'mapped' for q in mapped_quantities}
 
     def validate_mapping(self):
         """ Validate the mapping choices, warn and/or except on issues.
@@ -315,8 +329,13 @@ class Source:
             else:
                 scaledvals = rescale_values(np.array(mapvals), lims, plims)
                 self.mapping[key] =  list(scaledvals)
-            
-        # finally, iterate through sources and interpolate evo functions 
+
+        # keep the mapped values themselves before evolving parameters are
+        # replaced by interpolation functions below. Deep copy as the angle
+        # unwrapping further down modifies the mapped arrays in place.
+        self.mapped_samples = copy.deepcopy(self.mapping)
+
+        # finally, iterate through sources and interpolate evo functions
         for key in self.mapping:
             if key == "time_evo":
                 continue

--- a/src/strauss/sources.py
+++ b/src/strauss/sources.py
@@ -184,7 +184,7 @@ class Source:
             if (ang in params) and not (ang in self.map_lims) and not (self.angle_unit):
                 warn_text += f" - no angle unit or map_lims entry for {ang}, assuming values (0,1] for fractions of a circle (cycles)  \n"
             if (ang in self.map_lims) and (self.angle_unit):
-                warn_text += f" - map_lims entry for '{ang}' ('{ang}':{self.map_lims['ang']}) provided alongside "
+                warn_text += f" - map_lims entry for '{ang}' ('{ang}':{self.map_lims[ang]}) provided alongside "
                 warn_text += f"angle_unit={self.angle_unit}. Ignoring angle_unit for '{ang}'.\n"
                 
         # Finally, warn or except about any issues after full audit of mapping

--- a/src/strauss/stream.py
+++ b/src/strauss/stream.py
@@ -13,6 +13,11 @@ import wavio
 import matplotlib.pyplot as plt
 from scipy.signal.windows import hann
 
+# frequency limits a filter cutoff sweeps between, in Hz, from the bottom
+# of hearing to just under the Nyquist frequency of a 44.1 kHz signal. The
+# cutoff parameter is mapped logarithmically between them
+filter_freq_lims = (20., 2.205e4)
+
 class Stream:
     """
     Stream object representing audio samples.
@@ -83,7 +88,8 @@ class Stream:
         self.values = self.buffers.to_stream()
         
     def filt_sweep(self, ffunc, fmap, qmap=lambda x:x*0 + 0.1,
-                   flo=20, fhi=2.205e4, qlo=0.5, qhi=10):
+                   flo=filter_freq_lims[0], fhi=filter_freq_lims[1],
+                   qlo=0.5, qhi=10):
         """
         Apply time varying filter to buffered stream
 

--- a/src/strauss/styles/__init__.py
+++ b/src/strauss/styles/__init__.py
@@ -558,6 +558,18 @@ class Style(MonitoredBaseModel):
     )
 
 
+    handle_nans: Literal['silent', 'interpolate'] = Field(
+        default='silent',
+        title='Non-finite Value Handling',
+        description='How missing (NaN or infinite) input data is handled. Both modes linearly '
+                    'interpolate the missing values in time, so that they do not propagate '
+                    'through the mapping; "interpolate" then sounds the interpolated data as it '
+                    'is, while "silent" additionally mutes the audio the missing data would have '
+                    'made, so that a gap in the data is heard as a gap in the sound.',
+        examples=['silent', 'interpolate']
+    )
+
+
     @field_validator('sources', mode='before')
     @classmethod
     def lowercase_type(cls, value: str):
@@ -575,6 +587,12 @@ class Style(MonitoredBaseModel):
     def lowercase_pitch_binning(cls, value: str):
         # Convert string to lowercase so that 'Adaptive', 'adaptive', and 'ADAPTIVE' are all valid.
         return value.lower()
+
+    @field_validator('handle_nans', mode='before')
+    @classmethod
+    def lowercase_handle_nans(cls, value: str):
+        # Convert string to lowercase so that 'Silent', 'silent', and 'SILENT' are all valid.
+        return value.lower() if isinstance(value, str) else value
     
     
     @field_validator('max_notes_per_sec')

--- a/src/strauss/styles/__init__.py
+++ b/src/strauss/styles/__init__.py
@@ -443,7 +443,7 @@ class Style(MonitoredBaseModel):
         )
 
     merge_mode: Literal['average', 'central'] = Field(
-        default='average',
+        default='central',
         title='Event Merge Mode',
         description='How events merged together by "max_notes_per_sec" take their values. '
                     'Choose from "average", where the merged event takes the mean of all the '

--- a/src/strauss/styles/__init__.py
+++ b/src/strauss/styles/__init__.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, ConfigDict, PrivateAttr, Field, field_validator, model_validator
 from typing import Optional, Literal, Dict, List, Union, Tuple
-from ..sources import param_lim_dict as valid_params
+from ..sources import param_lim_dict as valid_params, spatial_angles
 from pathlib import Path
 import random
 import numpy as np
@@ -231,12 +231,17 @@ class Mapping(MonitoredBaseModel):
         
         if self.fixed is None:
             return self
-        
+
+        if self.output in spatial_angles:
+            # spatial angles are cyclic, so any value is valid - it is wrapped
+            # around the circle in the units given by angle_unit
+            return self
+
         valid_min, valid_max = valid_params[self.output]
-        
+
         if not valid_min <= self.fixed <= valid_max:
             raise ValueError('Fixed value must be between the limits of the output parameter.')
-        
+
         return self
     
 

--- a/src/strauss/styles/__init__.py
+++ b/src/strauss/styles/__init__.py
@@ -442,6 +442,19 @@ class Style(MonitoredBaseModel):
         examples=[15, 10, 7]
         )
 
+    merge_mode: Literal['average', 'central'] = Field(
+        default='average',
+        title='Event Merge Mode',
+        description='How events merged together by "max_notes_per_sec" take their values. '
+                    'Choose from "average", where the merged event takes the mean of all the '
+                    'events it stands for, and so represents all of them but corresponds to no '
+                    'single data point, and "central", where it takes the values of the event '
+                    'closest to the middle of those merged, and so remains a real data point. '
+                    'Merged events always sound at the mean time of those merged, whichever is '
+                    'used, so that the maximum event rate is kept to.',
+        examples=['average', 'central']
+        )
+
     # The map is the list of Mapping objects which set up the sonification parameters and limits.
     map: List[Mapping] = Field(
         ...,
@@ -551,6 +564,12 @@ class Style(MonitoredBaseModel):
         # Convert string to lowercase so that 'Objects', 'objects', and 'OBJECTS' are all valid.
         return value.lower()
     
+    @field_validator('merge_mode', mode='before')
+    @classmethod
+    def lowercase_merge_mode(cls, value: str):
+        # Convert string to lowercase so that 'Average', 'average', and 'AVERAGE' are all valid.
+        return value.lower() if isinstance(value, str) else value
+
     @field_validator('pitch_binning', mode='before')
     @classmethod
     def lowercase_pitch_binning(cls, value: str):

--- a/src/strauss/styles/stars_appearing.yml
+++ b/src/strauss/styles/stars_appearing.yml
@@ -1,0 +1,32 @@
+name: "Stars Appearing"
+
+description: "Brightest stars appear first, pitch mapped to colour. Glockenspiel base sound."
+
+generator:
+  type: "sampler"
+  sample: "glockenspiel"
+
+sources: "events"
+
+max_notes_per_sec: 5
+
+map:
+
+  - input: "magnitude"
+    input_range: ["0%", "110%"]
+    output: "time"
+
+  - input: "colour"
+    output: "pitch"
+
+  - input: "azimuth"
+    output: "azimuth"
+
+  - input: "polar"
+    output: "polar"
+
+
+notes: ["G2", "D3", "G3", "B4", "F#4"]
+  
+  
+

--- a/src/strauss/utilities.py
+++ b/src/strauss/utilities.py
@@ -307,13 +307,52 @@ def merge_events_original(duration, max_rate, time, arglist):
         newargs.append(mean[~np.isnan(mean)])
     return newargs
 
-def merge_events(duration, max_rate, time, arglist):
+def merge_events(duration, max_rate, time, arglist, mode='average',
+                 time_index=None, cyclic=None, return_index=False):
+    """ Thin events down to a maximum rate.
+
+    Events are sorted by time and grouped into clusters no closer
+    together than the maximum rate allows, each cluster then yielding a
+    single event. Every cluster sounds at its mean time, which keeps
+    events at least a gap apart and so holds the rate to `max_rate`.
+
+    How the remaining properties are decided depends on `mode`:
+    `'average'` takes the mean of the cluster, so the event represents
+    all of its members but corresponds to no one input event, while
+    `'central'` takes them from the member sounding closest to the mean
+    time, so the event remains a real data point.
+
+    Args:
+      duration (:obj:`float`): sonification duration in seconds
+      max_rate (:obj:`float`): maximum events per second
+      time (:obj:`ndarray`): event times, as a fraction of the
+        sonification length
+      arglist (:obj:`list(ndarray)`): input data arrays, one value per
+        event
+      mode (`optional`, :obj:`str`): `'average'` to average each
+        cluster, or `'central'` to take its most central event
+      time_index (`optional`, :obj:`int`): index in `arglist` of the
+        data mapped to time, which is always averaged so that events
+        keep to `max_rate`
+      cyclic (`optional`, :obj:`dict`): indices in `arglist` of data
+        that wraps around, with entries giving the value it wraps at
+        (e.g. 360, for an azimuth in degrees). These are averaged as
+        directions rather than as numbers, so that a cluster straddling
+        the wrap point does not average to the opposite direction.
+      return_index (`optional`, :obj:`bool`): if True, also return the
+        index of each cluster's most central event. Values that cannot
+        be averaged (e.g. names) can be carried through the thinning by
+        indexing them with this.
+
+    Returns:
+      sort_args (:obj:`list(ndarray)`): merged data arrays, in time order
+      repdx (:obj:`ndarray`, `optional`): index into the input events of
+      the most central event of each merged event
+    """
     min_gap = 1./(max_rate*duration)
     sortdx = np.argsort(time)
     sort_time = time[sortdx]
-    
-    gaps = np.diff(sort_time)
-    new_cluster_mask = gaps >= min_gap
+
     start_indices = [0]
     anchor = sort_time[0]
 
@@ -325,11 +364,40 @@ def merge_events(duration, max_rate, time, arglist):
     start_indices = np.array(start_indices)
     end_indices = np.append(start_indices[1:], len(sort_time))
     cluster_sizes = end_indices - start_indices
+
+    # the event of each cluster sounding closest to the cluster's mean
+    # time best represents it, whether or not we take its properties
+    mean_times = np.add.reduceat(sort_time, start_indices) / cluster_sizes
+    repdx = np.empty(start_indices.size, dtype=int)
+    for i in range(start_indices.size):
+        lo, hi = start_indices[i], end_indices[i]
+        repdx[i] = lo + np.argmin(abs(sort_time[lo:hi] - mean_times[i]))
+
+    cyclic = cyclic or {}
+
     sort_args = []
     for i in range(len(arglist)):
         sortvals = np.array(arglist[i])[sortdx]
-        merged_values = np.add.reduceat(sortvals, start_indices) / cluster_sizes
+        if (mode == 'central') and (i != time_index):
+            merged_values = sortvals[repdx]
+        elif i in cyclic:
+            # average as a direction, so that a cluster straddling the wrap
+            # point averages to the direction it lies in, rather than to the
+            # opposite one (e.g. 359 and 1 degrees to 0, not to 180)
+            period = cyclic[i]
+            phase = 2*np.pi*sortvals/period
+            sines = np.add.reduceat(np.sin(phase), start_indices)
+            cosines = np.add.reduceat(np.cos(phase), start_indices)
+            merged_values = np.arctan2(sines, cosines) % (2*np.pi)
+            merged_values *= period/(2*np.pi)
+        else:
+            # time is averaged whatever the mode, to hold the event rate
+            merged_values = np.add.reduceat(sortvals, start_indices) / cluster_sizes
         sort_args.append(merged_values)
+
+    if return_index:
+        return sort_args, sortdx[repdx]
+
     return sort_args
                 
         

--- a/src/strauss/utilities.py
+++ b/src/strauss/utilities.py
@@ -205,6 +205,58 @@ def const_or_evo(x,t):
     else:
         return x
 
+def decimals_for_range(span, steps=1000):
+    """Decimal places that resolve a range into a number of steps.
+
+    A quantity is worth reporting to about a thousandth of the range it
+    covers, which is finer than any of it is heard. Spatial angles over
+    360 degrees are then given to a tenth of a degree, and the same
+    angles in cycles to a thousandth of a cycle.
+
+    Args:
+      span (:obj:`float`): the range the quantity covers
+      steps (`optional`, :obj:`int`): steps to resolve it into
+
+    Returns:
+      decimals (:obj:`int`): decimal places to round to, never negative
+    """
+    if (not np.isfinite(span)) or (span <= 0):
+        return 3
+
+    return int(max(0, -np.floor(np.log10(span/steps))))
+
+def amplitude_to_db(amplitude):
+    """Express an amplitude in decibels.
+
+    Amplitudes are fractions of the loudest signal, which is 0 dB, and
+    silence is minus infinity decibels. Decibels of amplitude are used
+    throughout, so a factor of 20 rather than the 10 used for power.
+
+    Args:
+      amplitude (:obj:`array-like` or :obj:`float`): amplitude, as a
+        fraction of the loudest signal
+
+    Returns:
+      db (:obj:`array-like` or :obj:`float`): the amplitude in decibels
+    """
+    with np.errstate(divide='ignore', invalid='ignore'):
+        return 20*np.log10(np.asarray(amplitude, dtype=float))
+
+def db_to_amplitude(db):
+    """Express decibels as an amplitude.
+
+    Inverse of :func:`amplitude_to_db`, giving the amplitude as a
+    fraction of the loudest signal.
+
+    Args:
+      db (:obj:`array-like` or :obj:`float`): a level in decibels
+
+    Returns:
+      amplitude (:obj:`array-like` or :obj:`float`): the corresponding
+      amplitude
+    """
+    return pow(10., np.asarray(db, dtype=float)/20.)
+
 def rescale_values(x, oldlims, newlims):
     """
     Rescale x values defined by limits oldlims to new limits newlims

--- a/src/strauss/utilities.py
+++ b/src/strauss/utilities.py
@@ -431,22 +431,31 @@ def merge_events(duration, max_rate, time, arglist, mode='average',
 
     sort_args = []
     for i in range(len(arglist)):
-        sortvals = np.array(arglist[i])[sortdx]
-        if (mode == 'central') and (i != time_index):
-            merged_values = sortvals[repdx]
-        elif i in cyclic:
-            # average as a direction, so that a cluster straddling the wrap
-            # point averages to the direction it lies in, rather than to the
-            # opposite one (e.g. 359 and 1 degrees to 0, not to 180)
-            period = cyclic[i]
-            phase = 2*np.pi*sortvals/period
-            sines = np.add.reduceat(np.sin(phase), start_indices)
-            cosines = np.add.reduceat(np.cos(phase), start_indices)
-            merged_values = np.arctan2(sines, cosines) % (2*np.pi)
-            merged_values *= period/(2*np.pi)
-        else:
-            # time is averaged whatever the mode, to hold the event rate
-            merged_values = np.add.reduceat(sortvals, start_indices) / cluster_sizes
+        sortvals = np.array(arglist[i], dtype=float)[sortdx]
+
+        # non-finite values are left out of the averages, so that one event
+        # with missing data does not take its whole cluster with it. A
+        # cluster averages to NaN only where none of its members has a value
+        good = np.isfinite(sortvals)
+        ngood = np.add.reduceat(good.astype(float), start_indices)
+        with np.errstate(invalid='ignore', divide='ignore'):
+            if (mode == 'central') and (i != time_index):
+                merged_values = sortvals[repdx]
+            elif i in cyclic:
+                # average as a direction, so that a cluster straddling the wrap
+                # point averages to the direction it lies in, rather than to the
+                # opposite one (e.g. 359 and 1 degrees to 0, not to 180)
+                period = cyclic[i]
+                phase = 2*np.pi*np.where(good, sortvals, 0.)/period
+                sines = np.add.reduceat(np.where(good, np.sin(phase), 0.), start_indices)
+                cosines = np.add.reduceat(np.where(good, np.cos(phase), 0.), start_indices)
+                merged_values = np.arctan2(sines, cosines) % (2*np.pi)
+                merged_values *= period/(2*np.pi)
+                merged_values = np.where(ngood > 0, merged_values, np.nan)
+            else:
+                # time is averaged whatever the mode, to hold the event rate
+                merged_values = np.add.reduceat(np.where(good, sortvals, 0.),
+                                                start_indices) / ngood
         sort_args.append(merged_values)
 
     if return_index:
@@ -459,6 +468,82 @@ def merge_events(duration, max_rate, time, arglist, mode='average',
     return sort_args
                 
         
+def nan_mute_envelope(mask, times, ramp):
+    """ Build a gain curve muting the intervals where data is missing.
+
+    Returns the knots of a piecewise-linear curve that sits at full
+    volume where a source has data and at zero where it has none, with
+    a short ramp between the two so that the transition does not click.
+
+    The ramp down begins at the last sample before the gap, so that
+    sample still sounds at full volume, and the ramp up finishes at the
+    first sample after it, so that one does too. Where a gap is too
+    short to fit both ramps, the curve dips to zero at its midpoint
+    instead. A gap running to either end of the data has no sample on
+    that side to ramp from, and so simply starts or stays muted.
+
+    Args:
+      mask (:obj:`ndarray`): boolean, True where a sample is missing
+      times (:obj:`ndarray`): position of each sample on the axis the
+        knots are returned in, in ascending order
+      ramp (:obj:`float`): duration of the ramps, in the units of `times`
+
+    Returns:
+      knots (:obj:`tuple(ndarray)`): the `x` and `y` of the curve, or
+        :obj:`None` where nothing is missing and so nothing is muted
+    """
+    mask = np.asarray(mask, dtype=bool)
+    times = np.asarray(times, dtype=float)
+
+    if not mask.any():
+        return None
+
+    if mask.all():
+        return np.array([times[0], times[-1]]), np.zeros(2)
+
+    # bracket each contiguous run of missing samples, as the padding makes
+    # a run at either end of the data show up as a change like any other
+    padded = np.concatenate(([False], mask, [False]))
+    changes = np.flatnonzero(np.diff(padded.astype(int)))
+    starts, ends = changes[0::2], changes[1::2] - 1
+
+    xs = [times[0]]
+    ys = [0. if mask[0] else 1.]
+
+    for first, last in zip(starts, ends):
+        has_pre, has_post = first > 0, last < mask.size - 1
+        pre = times[first-1] if has_pre else None
+        post = times[last+1] if has_post else None
+
+        # ramp down from the last sample with data, and up to the next one
+        down = min(pre + ramp, times[first]) if has_pre else None
+        up = max(post - ramp, times[last]) if has_post else None
+
+        # a gap too short for both ramps dips to zero at its midpoint
+        if has_pre and has_post and (down > up):
+            down = up = 0.5*(pre + post)
+
+        if has_pre:
+            xs += [pre, down]
+            ys += [1., 0.]
+        if has_post:
+            xs += [up, post]
+            ys += [0., 1.]
+
+    xs.append(times[-1])
+    ys.append(0. if mask[-1] else 1.)
+
+    # knots must be strictly increasing to interpolate between. Sorting the
+    # quieter of any pair sharing a position to the front keeps a mute from
+    # being widened away by a ramp knot landing on top of it
+    xs, ys = np.array(xs, dtype=float), np.array(ys, dtype=float)
+    order = np.lexsort((ys, xs))
+    xs, ys = xs[order], ys[order]
+    unique = np.append(True, np.diff(xs) > 0)
+
+    return xs[unique], ys[unique]
+
+
 def apply_fades(samples, srate, fdur=0.03):
     """ Apply de-click fades to a sample array
 

--- a/src/strauss/utilities.py
+++ b/src/strauss/utilities.py
@@ -339,15 +339,17 @@ def merge_events(duration, max_rate, time, arglist, mode='average',
         (e.g. 360, for an azimuth in degrees). These are averaged as
         directions rather than as numbers, so that a cluster straddling
         the wrap point does not average to the opposite direction.
-      return_index (`optional`, :obj:`bool`): if True, also return the
-        index of each cluster's most central event. Values that cannot
-        be averaged (e.g. names) can be carried through the thinning by
+      return_index (`optional`, :obj:`bool`): if True, also return how
+        the input events fall into clusters. Values that cannot be
+        averaged (e.g. names) can be carried through the thinning by
         indexing them with this.
 
     Returns:
       sort_args (:obj:`list(ndarray)`): merged data arrays, in time order
-      repdx (:obj:`ndarray`, `optional`): index into the input events of
-      the most central event of each merged event
+      clusters (:obj:`dict`, `optional`): describing the cluster behind
+      each merged event, with `'central'`, `'first'` and `'last'`
+      indexing the input events of its most central, earliest and latest
+      members, and `'size'` giving the number of events merged
     """
     min_gap = 1./(max_rate*duration)
     sortdx = np.argsort(time)
@@ -396,7 +398,11 @@ def merge_events(duration, max_rate, time, arglist, mode='average',
         sort_args.append(merged_values)
 
     if return_index:
-        return sort_args, sortdx[repdx]
+        clusters = {'central': sortdx[repdx],
+                    'first': sortdx[start_indices],
+                    'last': sortdx[end_indices-1],
+                    'size': cluster_sizes}
+        return sort_args, clusters
 
     return sort_args
                 

--- a/tests/pre-merge/NaNHandling.ipynb
+++ b/tests/pre-merge/NaNHandling.ipynb
@@ -1,0 +1,152 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "596da825-87c8-4c28-87ac-3d4878ba5c62",
+   "metadata": {
+    "id": "596da825-87c8-4c28-87ac-3d4878ba5c62"
+   },
+   "outputs": [],
+   "source": [
+    "# install the source_table branch for now\n",
+    "!git clone -b nan_handling --single-branch https://github.com/james-trayford/strauss.git\n",
+    "!pip install \"strauss @ git+https://github.com/james-trayford/strauss.git@nan_handling\" -q\n",
+    "%cd strauss/examples/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d279dda5-82f2-4001-8b66-b80874473cf1",
+   "metadata": {},
+   "source": [
+    "# NaN handling examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "238d857a-45b6-4232-a3b3-f9b7dac978d4",
+   "metadata": {},
+   "source": [
+    "Examples of how NaN values are handled "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cee27841-c539-448b-9f23-1ae93cafe48d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import strauss\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5dbce421-36e4-4bb1-a444-254f2f00a92b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.linspace(0, 90, 400)\n",
+    "y =  np.sin(x/2)\n",
+    "z = 0.1*x**2 - x - 5 \n",
+    "\n",
+    "idx = y.size//5\n",
+    "y[idx:idx+30] = np.nan\n",
+    "\n",
+    "plt.plot(x,y)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "933448d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "handle_type = 'silent' # this is the default, but can be changed to 'interpolate' "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8eb8544",
+   "metadata": {},
+   "source": [
+    "### NaN-handled audio"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3bab9982-afef-47a3-9701-fbf1dc8df407",
+   "metadata": {},
+   "source": [
+    "Try **`default`** sonification of an Object - the region of `NaN`s are muted or interpolated "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f17f98d-c8b8-400e-a7d0-ed75961d7aeb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "strauss.sonify(x, y, handle_nans=handle_type)\n",
+    "mapped = strauss.get_table()\n",
+    "fixed = strauss.get_fixed_table()\n",
+    "strauss.display()\n",
+    "print(\"\\n\\nMapped sources table:\")\n",
+    "strauss.list_tables()\n",
+    "strauss.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1d0c099",
+   "metadata": {},
+   "source": [
+    "Or for Events, simply skip `NaN`-carrying event sources, or interpolate based on surrounding values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "989be4d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "strauss.sonify(x, -y, style='mallets', handle_nans=handle_type)\n",
+    "afig = strauss._get_current_figure()\n",
+    "strauss.display()\n",
+    "strauss.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "venv (3.12.13.final.0)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/pre-merge/SourceTables.ipynb
+++ b/tests/pre-merge/SourceTables.ipynb
@@ -134,7 +134,7 @@
    "outputs": [],
    "source": [
     "strauss.sonify(x, y)\n",
-    "strauss.sonify(x, -y, style='fixed_test')\n",
+    "strauss.sonify(x, -y, style='mallets')\n",
     "afig = strauss._get_current_figure()\n",
     "strauss.display()\n",
     "strauss.close()"
@@ -366,22 +366,6 @@
     "strauss.display()\n",
     "strauss.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2df69280",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9429b09b",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/tests/pre-merge/SourceTables.ipynb
+++ b/tests/pre-merge/SourceTables.ipynb
@@ -134,7 +134,7 @@
    "outputs": [],
    "source": [
     "strauss.sonify(x, y)\n",
-    "strauss.sonify(x, -y, style='windy')\n",
+    "strauss.sonify(x, -y, style='fixed_test')\n",
     "afig = strauss._get_current_figure()\n",
     "strauss.display()\n",
     "strauss.close()"
@@ -157,7 +157,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "afig.get_table('sonification_1')"
+    "afig.get_table('sonification_2')"
    ]
   },
   {
@@ -366,6 +366,22 @@
     "strauss.display()\n",
     "strauss.close()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2df69280",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9429b09b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tests/pre-merge/SourceTables.ipynb
+++ b/tests/pre-merge/SourceTables.ipynb
@@ -1,0 +1,399 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "596da825-87c8-4c28-87ac-3d4878ba5c62",
+   "metadata": {
+    "id": "596da825-87c8-4c28-87ac-3d4878ba5c62"
+   },
+   "outputs": [],
+   "source": [
+    "# install the source_table branch for now\n",
+    "!git clone -b source_tables --single-branch https://github.com/james-trayford/strauss.git\n",
+    "!pip install \"strauss @ git+https://github.com/james-trayford/strauss.git@source_table\" -q\n",
+    "%cd strauss/examples/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d279dda5-82f2-4001-8b66-b80874473cf1",
+   "metadata": {},
+   "source": [
+    "# Source Table examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "238d857a-45b6-4232-a3b3-f9b7dac978d4",
+   "metadata": {},
+   "source": [
+    "We now make timing tables from the `Sources` to allow for syncing (e.g. visuals) or just general inspection. Set up some data first:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cee27841-c539-448b-9f23-1ae93cafe48d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import strauss\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5dbce421-36e4-4bb1-a444-254f2f00a92b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.linspace(0, 90, 400)\n",
+    "y =  np.sin(x/2)\n",
+    "z = 0.1*x**2 - x - 5 "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8eb8544",
+   "metadata": {},
+   "source": [
+    "### Basic Tables"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3bab9982-afef-47a3-9701-fbf1dc8df407",
+   "metadata": {},
+   "source": [
+    "Try **`default`** sonification with nothing added:   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f17f98d-c8b8-400e-a7d0-ed75961d7aeb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "strauss.sonify(x, y)\n",
+    "afig = strauss._get_current_figure()\n",
+    "mapped = afig.get_table()\n",
+    "fixed = afig.get_fixed_table()\n",
+    "strauss.display()\n",
+    "print(\"\\n\\nMapped sources table:\")\n",
+    "afig.list_tables()\n",
+    "strauss.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1f0b603-42d4-47e4-8ecc-8c66cc894c5c",
+   "metadata": {},
+   "source": [
+    "This produces a single _\"object\"_ source with a single pitch-mapping. For `Objects`, each row is a single data point with columns denoting property value at each time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8a44804-4c2d-4739-b3a8-e73acba2a413",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# show mapped sources table (just one in this case)\n",
+    "mapped "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4afcbd81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# show fixed sources table\n",
+    "fixed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1d0c099",
+   "metadata": {},
+   "source": [
+    "If I have multipler sonifications, I can get the table for each one by passing the sonification name to `get_table()`. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "989be4d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "strauss.sonify(x, y)\n",
+    "strauss.sonify(x, -y, style='windy')\n",
+    "afig = strauss._get_current_figure()\n",
+    "strauss.display()\n",
+    "strauss.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75f73c27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "afig.list_tables()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b449d591",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "afig.get_table('sonification_1')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0bae852",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "afig.get_table('sonification_2')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa523a42",
+   "metadata": {},
+   "source": [
+    "### `Events` Sources and naming"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62634306",
+   "metadata": {},
+   "source": [
+    "First, lets generate a load of names for the sources. Using IAU star names to generate a list of nouns of length `len(x)`..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58a8123f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import random"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "712f61b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl https://raw.githubusercontent.com/cyschneck/iau-star-names/main/iau_proper_stars.csv > iau_proper_stars.csv\n",
+    "names = sorted(random.sample(list(pd.read_csv(\"iau_proper_stars.csv\")[\"Proper Names\"]), len(x)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12b109c4",
+   "metadata": {},
+   "source": [
+    "First without explicit naming let's make a `mallets` sonification. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0d0d65e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "soni =  strauss.sonify(x, y, \n",
+    "                       style='mallets')\n",
+    "afig = strauss._get_current_figure()\n",
+    "display(afig.get_table())\n",
+    "strauss.display()\n",
+    "strauss.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4da608c",
+   "metadata": {},
+   "source": [
+    "Note that rendering the sonification itself is not necessary to produce the tables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5adb4643",
+   "metadata": {},
+   "source": [
+    "Now with the names, and we'll reverse all arrays  to validate the tables should always return in time order...."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "854830e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "soni =  strauss.sonify(x[::-1], y[::-1], \n",
+    "                       style='mallets',\n",
+    "                       source_names=names[::-1])\n",
+    "afig = strauss._get_current_figure()\n",
+    "display(afig.get_table())\n",
+    "strauss.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b52aefb",
+   "metadata": {},
+   "source": [
+    "For `Events`, each row is a single event with columns denoting properties at their respective occurence time. Printing our first few input names for comparison:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e9f0820",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(names[:10])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78d7e028",
+   "metadata": {},
+   "source": [
+    "...notice that this isn't a complete list of provided names. This is because the `max_num_per_sec` assigned by the style merges some sources together. \n",
+    "\n",
+    "Now with named sources this can be problematic - if esch source is a particular star, say, we don't don't want to represent them as an 'average' star at an 'average' position in the sky (e.g. for _Betelgeuse_ and _Sirius_ an average of their colour, position, etc).\n",
+    "\n",
+    "This is why the **new default merge approach** is to take the average ***time*** an event sounds, but then take all the other properties from the entry closest in time to the mid point of the merged sources. \n",
+    "\n",
+    "We can use the old approach using a _kwarg_ or style parameter..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb3f5fbd-8398-4ca2-a18f-3de65f1acc53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "soni =  strauss.sonify(x, y, \n",
+    "                       style='mallets', \n",
+    "                       source_names=names,\n",
+    "                       merge_mode='average', # <== this is the new parameter\n",
+    "                       num_notes_per_sec=1)\n",
+    "afig = strauss._get_current_figure()\n",
+    "strauss.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb38d777",
+   "metadata": {},
+   "source": [
+    "now the names reflect that they are the average of multiple sources. The name is listed as `{earliest}->{latest}` to indicate the names of the earliest and latest source occuring in the cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ab30495",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "afig.get_table('sonification_1')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b75a5d58",
+   "metadata": {},
+   "source": [
+    "### Complex events with spatial angles"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "605a4428-5fd6-4324-ab9c-10ebdbfa2e91",
+   "metadata": {},
+   "source": [
+    "Finally, sources with spatial angles use updated angle behaviour. The style file and kwargs now have `angle_unit` parameter I can set to work in a particular unit convention (where for a full circle _'cycles'_ expects 0->1, _'degrees'_ expects 0->360 and _'radians'_ expects 0->2π)\n",
+    "\n",
+    "This unit is what is expected for spatial angle fields, allowing > the limits to be used (e.g. 720 degrees). If set but the input and table units willuse that convention, if unset we expect cycles (following ~old behaviour) but tabulate in degrees.\n",
+    "\n",
+    "Lets wrap this around the listener twice (azimuth: 0 -> 720 degrees) in the listener plane (polar: 90 degrees)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81f578c7-d562-4e46-926c-638b81f52a67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "windy = strauss.sonify(x, # time\n",
+    "                       y, # pitch\n",
+    "                       720*x/x.max(), # azimuth angle\n",
+    "                       x*0 + 90, # polar angle\n",
+    "                       angle_unit='degrees',\n",
+    "                       style='stars_appearing', \n",
+    "                       source_names=names,\n",
+    "                       merge_mode='central')\n",
+    "afig = strauss._get_current_figure()\n",
+    "display(afig.get_table(\"sonification_1\"))\n",
+    "strauss.display()\n",
+    "strauss.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "venv (3.12.13)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/pre-merge/SourceTables.ipynb
+++ b/tests/pre-merge/SourceTables.ipynb
@@ -79,12 +79,11 @@
    "outputs": [],
    "source": [
     "strauss.sonify(x, y)\n",
-    "afig = strauss._get_current_figure()\n",
-    "mapped = afig.get_table()\n",
-    "fixed = afig.get_fixed_table()\n",
+    "mapped = strauss.get_table()\n",
+    "fixed = strauss.get_fixed_table()\n",
     "strauss.display()\n",
     "print(\"\\n\\nMapped sources table:\")\n",
-    "afig.list_tables()\n",
+    "strauss.list_tables()\n",
     "strauss.close()"
    ]
   },
@@ -124,7 +123,7 @@
    "id": "c1d0c099",
    "metadata": {},
    "source": [
-    "If I have multipler sonifications, I can get the table for each one by passing the sonification name to `get_table()`. For example:"
+    "If I have multiple sonifications, I can get the table for each one by passing the sonification name to `get_table()`. For example:"
    ]
   },
   {
@@ -227,8 +226,7 @@
     "\n",
     "soni =  strauss.sonify(x, y, \n",
     "                       style='mallets')\n",
-    "afig = strauss._get_current_figure()\n",
-    "display(afig.get_table())\n",
+    "display(strauss.get_table())\n",
     "strauss.display()\n",
     "strauss.close()"
    ]
@@ -259,8 +257,7 @@
     "soni =  strauss.sonify(x[::-1], y[::-1], \n",
     "                       style='mallets',\n",
     "                       source_names=names[::-1])\n",
-    "afig = strauss._get_current_figure()\n",
-    "display(afig.get_table())\n",
+    "display(strauss.get_table())\n",
     "strauss.close()"
    ]
   },
@@ -365,8 +362,7 @@
     "                       style='stars_appearing', \n",
     "                       source_names=names,\n",
     "                       merge_mode='central')\n",
-    "afig = strauss._get_current_figure()\n",
-    "display(afig.get_table(\"sonification_1\"))\n",
+    "display(strauss.get_table(\"sonification_1\"))\n",
     "strauss.display()\n",
     "strauss.close()"
    ]

--- a/tests/pre-merge/SourceTables.ipynb
+++ b/tests/pre-merge/SourceTables.ipynb
@@ -10,7 +10,7 @@
    "outputs": [],
    "source": [
     "# install the source_table branch for now\n",
-    "!git clone -b source_tables --single-branch https://github.com/james-trayford/strauss.git\n",
+    "!git clone -b source_table --single-branch https://github.com/james-trayford/strauss.git\n",
     "!pip install \"strauss @ git+https://github.com/james-trayford/strauss.git@source_table\" -q\n",
     "%cd strauss/examples/"
    ]


### PR DESCRIPTION
This PR merge is built on https://github.com/james-trayford/strauss/pull/61#issue-5140469048 (merge this PR after #61)

---

[Test functionality here](https://githubtocolab.com/james-trayford/strauss/blob/nan_handling/tests/pre-merge/NaNHandling.ipynb)

---

 Handle NaN and inf values in input data

## Current Behaviour

Currently, A single `NaN` in an input column ran through the percentiles that set the mapping limits, came back as `NaN`, which propagated when percentiles were taken. Typically resulted in silent sonifications where.

## New Features

A `handle_nans` control, settable as a `Style` field, a `sonify()` keyword, and a
kwarg on `Sources` and `Sonification`. Both modes record what was missing in
`Sources.nan_mask` and linearly interpolate it in time, so it can no longer
propagate through the mapping. They differ in what happens to the audio:

- **`'interpolate'`** sounds the interpolated data as it is.
- **`'silent'`** (default) additionally mutes the audio the missing data would have
  made, so a gap in the data is heard as a gap in the sound.

`±inf` is treated as `NaN` throughout.

### Per source type

- `Events`: skipped outright — discrete in time, so no interval within one to mute. `n_sources` shrinks and `source_names` thin alongside |
- `Objects`: muted over the missing interval, ramping down over `declick_time` (30 ms) from the last point with data and back up to the next, so the gap doesn't click. A gap too short for both ramps dips to zero at its midpoint 
- For `spectrum` always zeroed, not interpolated — a missing bin means no power at that frequency rather than a gap in the data, so it doesn't mute the whole source.

The mask is built **after** the mapping functions run, so values made non-finite by
the mapping itself (`log10` of a negative, `reciprocal` of zero) are caught too.

### Cases with nothing to interpolate from

Approach is to warn rather than error if NaNs complete mute a source or column has no info

- a **missing constant** on an `Objects` source takes the median of what the other
  objects give that parameter;
- a **wholly missing column** maps to the middle of its range;
- a **non-finite `time` or `time_evo`** is dropped in both modes, having no point in
  the sonification to be placed at.

## Also fixed

- `set_limits` ignores non-finite values, so one `NaN` no longer sets the range for
  every source.
- `merge_events` no longer lets one missing value take its whole cluster with it — a
  cluster averages to `NaN` only where none of its members has a value. Events with a
  non-finite `time` are dropped before merging, as they can't be sorted into a cluster.
- `Events.fromdict` / `Objects.fromdict` now raise on a mapped property missing from
  the data, rather than constructing an unraised `Exception` and failing later, and
  take `n_sources` from the first mapped quantity rather than from whichever the loop
  left behind.
- Tables gain a `Missing` column flagging what sounds at an interpolated value. It
  only appears where something is missing.